### PR TITLE
Add TIFF-only input support for non-ScanBox microscopes

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -16,13 +16,29 @@ python master_pipeline.py --manifest examples/your_manifest.hjson
 python master_pipeline.py --manifest examples/your_manifest.hjson --only_hcr
 ```
 
+## Choosing a Manifest Template
+
+| Template | `input_format` | When to use |
+|----------|---------------|-------------|
+| `demo_standard.hjson` | `sbx` | ScanBox 2P + HCR, low-res (Suite2p mean image directly) |
+| `demo_hires.hjson` | `sbx` | ScanBox 2P + HCR, hi-res anatomical tiles (stitch + unwarp) |
+| `demo_tiff.hjson` | `tiff` | Non-ScanBox microscope — bring your own pre-processed 2P mean images |
+| `demo_hcr_only.hjson` | n/a | HCR confocal only, no 2P data (`--only_hcr` flag) |
+| `demo.hjson` | `sbx` | General ScanBox template with all options documented |
+
+**Quick guide:**
+- **ScanBox user with .sbx files?** Use `demo_standard.hjson` or `demo_hires.hjson`
+- **Different microscope, have TIFF mean images?** Use `demo_tiff.hjson`
+- **Only HCR confocal, no 2P?** Use `demo_hcr_only.hjson`
+
 ## Execution Modes
 
 | Mode | Flag | Template | When to use |
 |------|------|----------|-------------|
 | **HCR-only** | `--only_hcr` | `demo_hcr_only.hjson` | You only have HCR confocal data, no 2P |
-| **Full + hi-res** | (none) | `demo_hires.hjson` | 2P + HCR, with high-res anatomical tile runs |
-| **Full + standard** | (none) | `demo_standard.hjson` | 2P + HCR, no high-res tiles (uses Suite2p mean image directly) |
+| **Full + hi-res** | (none) | `demo_hires.hjson` | 2P + HCR, with high-res anatomical tile runs (ScanBox) |
+| **Full + standard** | (none) | `demo_standard.hjson` | 2P + HCR, no high-res tiles (ScanBox, Suite2p mean image) |
+| **Full + TIFF** | (none) | `demo_tiff.hjson` | 2P + HCR, pre-processed TIFF mean images (any microscope) |
 | **General template** | (none) | `demo.hjson` | All options documented with comments |
 
 ## Pipeline Steps
@@ -75,19 +91,23 @@ The manifest is an [HJSON](https://hjson.github.io/) file (JSON with comments an
 
 #### 2P session fields
 
-| Field | Description |
-|-------|-------------|
-| `date` | Date string used in folder names: `{mouse}_{date}_{run}` |
-| `functional_run` | Run number containing the `suite2p/` folder |
-| `functional_planes` | Planes to process. **First = reference plane** for HCR landmark alignment |
-| `anatomical_hires_green_runs` | Hi-res tile run numbers (green channel). Paired 1:1 with red |
-| `anatomical_hires_red_runs` | Hi-res tile run numbers (red channel) |
-| `anatomical_lowres_green_runs` | Low-res anatomical run numbers (alternative to hi-res) |
-| `anatomical_lowres_red_runs` | Low-res anatomical run numbers |
-| `unwarp_config` | Distortion correction file (in `{base_path}/Calibration_files_for_unwarping/`) |
-| `unwarp_steps` | Number of unwarp interpolation steps |
+| Field | Required | Description |
+|-------|----------|-------------|
+| `input_format` | **Yes** | `"sbx"` (ScanBox) or `"tiff"` (pre-processed TIFFs) |
+| `date` | Yes | Date string used in folder names: `{mouse}_{date}_{run}` |
+| `functional_planes` | Yes | Planes to process. **First = reference plane** for HCR landmark alignment |
+| `functional_run` | SBX only | Run number containing the `suite2p/` folder |
+| `anatomical_hires_green_runs` | SBX only | Hi-res tile run numbers (green channel). Paired 1:1 with red |
+| `anatomical_hires_red_runs` | SBX only | Hi-res tile run numbers (red channel) |
+| `anatomical_lowres_green_runs` | SBX only | Low-res anatomical run numbers (alternative to hi-res) |
+| `anatomical_lowres_red_runs` | SBX only | Low-res anatomical run numbers |
+| `unwarp_config` | SBX only | Distortion correction file (in `{base_path}/Calibration_files_for_unwarping/`) |
+| `unwarp_steps` | SBX only | Number of unwarp interpolation steps |
+| `has_hires` | TIFF only | Set `true` if providing pre-stitched hi-res images (default: `false`) |
 
-> **Note:** Set either hi-res or low-res anatomical runs, not both. Leave both empty to use only the Suite2p mean image.
+> **SBX mode:** Set either hi-res or low-res anatomical runs, not both. Leave both empty to use only the Suite2p mean image.
+>
+> **TIFF mode:** Place your pre-processed mean images in the OUTPUT directory before running. See `demo_tiff.hjson` for file placement instructions.
 
 #### HCR round fields
 
@@ -121,7 +141,7 @@ All default to `"manual"`. Set to `"auto"` to use automated alternatives:
 
 ## Folder Structure
 
-The pipeline expects this input layout and creates `OUTPUT/` alongside it:
+### SBX mode (`input_format: "sbx"`)
 
 ```
 {base_path}/
@@ -150,6 +170,30 @@ The pipeline expects this input layout and creates `OUTPUT/` alongside it:
             ├── aligned_masks/
             └── aligned_extracted_features/
                 └── merged_table_plane{N}.csv   ← final output
+```
+
+### TIFF mode (`input_format: "tiff"`)
+
+Place your pre-processed mean images **before** running the pipeline:
+
+```
+{base_path}/
+└── {mouse_name}/
+    ├── HCR/
+    │   ├── {mouse}_HCR01.tif
+    │   └── ...
+    └── OUTPUT/
+        └── 2P/
+            └── cellpose/                        ← YOU CREATE THIS
+                ├── lowres_meanImg_C0_plane0.tiff     (green only, 2D float32)
+                └── lowres_meanImg_C0_plane1.tiff     (one per plane)
+```
+
+For green+red, use `lowres_meanImg_C01_plane{N}.tiff` (CYX, 2 channels) instead.
+
+For hi-res (`has_hires: true`), pre-stitch your tiles and place them at:
+```
+OUTPUT/2P/tile/stitched/hires_stitched_plane{N}.tiff   (CYX, float32)
 ```
 
 ## Re-Entry / Resume

--- a/examples/demo.hjson
+++ b/examples/demo.hjson
@@ -27,6 +27,9 @@
                     // Date string used in folder names: {mouse}_{date}_{run}
                     date: "240101"
 
+                    // Input format: "sbx" (ScanBox) or "tiff" (pre-processed TIFFs)
+                    input_format: "sbx"
+
                     // Run number containing the suite2p/ folder
                     functional_run: ["001"]
 

--- a/examples/demo_hires.hjson
+++ b/examples/demo_hires.hjson
@@ -21,6 +21,7 @@
             sessions: [
                 {
                     date: "240101"
+                    input_format: "sbx"
                     functional_run: ["001"]
                     functional_planes: ["1", "0", "2", "3"]
 

--- a/examples/demo_tiff.hjson
+++ b/examples/demo_tiff.hjson
@@ -1,42 +1,39 @@
 {
     // =========================================================================
-    // EASIFISH — FULL PIPELINE, STANDARD (LOW-RES) MODE
+    // EASIFISH — TIFF INPUT MODE (NON-SCANBOX MICROSCOPES)
     //
-    // Use when you have both 2P and HCR data, but NO high-resolution
-    // anatomical tile runs. The pipeline uses the Suite2p mean image directly
-    // for 2P→HCR registration (no stitching/unwarping step).
+    // Use when your 2P data is already pre-processed as TIFF mean images
+    // (e.g., from a different microscope, or manually extracted).
+    // No SBX files or Suite2p output needed.
+    //
+    // BEFORE RUNNING, place your mean images in the OUTPUT directory:
+    //
+    //   Green only (2D, float32):
+    //     {base_path}/{mouse}/OUTPUT/2P/cellpose/lowres_meanImg_C0_plane{N}.tiff
+    //
+    //   Green + red (CYX, 2 channels, float32):
+    //     {base_path}/{mouse}/OUTPUT/2P/cellpose/lowres_meanImg_C01_plane{N}.tiff
+    //
+    //   Hi-res pre-stitched (CYX, float32) — set has_hires: true below:
+    //     {base_path}/{mouse}/OUTPUT/2P/tile/stitched/hires_stitched_plane{N}.tiff
     //
     // Run with:
     //   python master_pipeline.py --manifest your_file.hjson
-    //
-    // Pipeline: HCR registration → HCR cellpose → Suite2p extraction →
-    //   2P cellpose → 2P→HCR registration → mask alignment → merged tables
     // =========================================================================
 
     data: {
         base_path: "/mnt/nasquatch/data/2p/YOUR_LAB/EASI_FISH/pipeline"
-        mouse_name: "MOUSE001"
+        mouse_name: "SAMPLE001"
 
         two_photon_imaging: {
             sessions: [
                 {
-                    date: "240101"
-                    input_format: "sbx"
-                    functional_run: ["001"]
+                    date: "250101"
+                    input_format: "tiff"
                     functional_planes: ["0"]
 
-                    // No hi-res runs — standard mode
-                    anatomical_hires_green_runs: []
-                    anatomical_hires_red_runs: []
-
-                    // Optional: low-res anatomical runs for red channel overlay.
-                    // If you have a separate red channel run, list it here.
-                    anatomical_lowres_green_runs: ["001"]
-                    anatomical_lowres_red_runs: ["002"]
-
-                    // Not needed in standard mode, but keep a placeholder
-                    unwarp_config: ""
-                    unwarp_steps: 28
+                    // Uncomment if providing pre-stitched hi-res images:
+                    // has_hires: true
                 }
             ]
         }
@@ -46,11 +43,6 @@
                 {
                     round: "01"
                     channels: ["DAPI", "PROBE_A", "PROBE_B"]
-                    resolution: [1.515, 1.515, 5.0]
-                }
-                {
-                    round: "02"
-                    channels: ["DAPI", "PROBE_C", "PROBE_D"]
                     resolution: [1.515, 1.515, 5.0]
                 }
             ]

--- a/master_pipeline.py
+++ b/master_pipeline.py
@@ -100,7 +100,8 @@ def main(args = None):
                 full_manifest, session, has_hires,
                 automation_enabled=(automation['twop_to_hcr'] == 'auto')
             )
-            sg.extract_electrophysiology_intensities(full_manifest, session)
+            if session.get('input_format', 'sbx') != 'tiff':
+                sg.extract_electrophysiology_intensities(full_manifest, session)
 
         # Now align 2P masks to HCR and merge (needs twop_aligned_3d.tiff from above)
         for plane in all_planes:
@@ -119,16 +120,25 @@ def main(args = None):
 def process_plane(full_manifest, session, has_hires):
     """Process 2P data for a single plane (no HCR processing - that's done once in main)."""
     plane = session['functional_plane'][0]
+    input_format = session.get('input_format', 'sbx')
     rprint(f"\n[bold green]Processing 2P plane {plane}[/bold green]")
 
-    if has_hires:
-        tl.process_session_sbx(full_manifest, session)
-        tl.unwarp_tiles(full_manifest, session)
-        tl.stitch_tiles_and_rotate(full_manifest, session)
-        fc.extract_suite2p_registered_planes(full_manifest, session)
+    if input_format == 'tiff':
+        # TIFF mode: user provides pre-processed images, just rotate them
+        if has_hires:
+            tl.stitch_tiles_and_rotate(full_manifest, session)
+        else:
+            fc.rotate_2p_plane(full_manifest, session)
     else:
-        has_red = bool(session.get('anatomical_lowres_red_runs'))
-        fc.extract_suite2p_registered_planes(full_manifest, session, combine_with_red=has_red)
+        # SBX mode: full extraction pipeline
+        if has_hires:
+            tl.process_session_sbx(full_manifest, session)
+            tl.unwarp_tiles(full_manifest, session)
+            tl.stitch_tiles_and_rotate(full_manifest, session)
+            fc.extract_suite2p_registered_planes(full_manifest, session)
+        else:
+            has_red = bool(session.get('anatomical_lowres_red_runs'))
+            fc.extract_suite2p_registered_planes(full_manifest, session, combine_with_red=has_red)
 
     # Extract cellpose masks from 2p images
     sg.extract_2p_cellpose_masks(full_manifest, session)

--- a/src/functional.py
+++ b/src/functional.py
@@ -8,7 +8,11 @@ from .registrations import verify_rounds
 from .meta import check_rotation, get_rotation_config, parse_json
 from tifffile import imread as tif_imread
 from tifffile import imwrite as tif_imwrite
-from sbxreader import sbx_get_metadata, sbx_memmap
+try:
+    from sbxreader import sbx_get_metadata, sbx_memmap
+except ImportError:
+    sbx_get_metadata = None
+    sbx_memmap = None
 
 def get_number_of_suite2p_planes(suite2p_path: Path):
     """
@@ -76,6 +80,8 @@ def extract_suite2p_registered_planes(full_manifest: dict , session: dict, combi
     if combine_with_red:
         save_filename_C01 = save_path / f'lowres_meanImg_C01_plane{functional_plane}.tiff'
         if not save_filename_C01.exists():
+            if sbx_memmap is None:
+                raise ImportError("sbxreader is required for combine_with_red in SBX mode. Install with: pip install sbxreader")
             save_filename_green = save_path / f'lowres_meanImg_C0_plane{functional_plane}.tiff'
             img = tif_imread(save_filename_green)
             red_run = session['anatomical_lowres_red_runs'][0]
@@ -90,7 +96,33 @@ def extract_suite2p_registered_planes(full_manifest: dict , session: dict, combi
         channels_needed = 'C01'
 
     # Rotate the current functional plane
-    # (The pipeline calls this function once per plane being processed)
+    rotate_2p_plane(full_manifest, session, channels_needed=channels_needed)
+
+
+def rotate_2p_plane(full_manifest, session, channels_needed=None):
+    """Rotate a 2P mean image to match HCR orientation.
+
+    Works for both SBX-extracted and user-provided TIFFs.
+    For TIFF mode, auto-detects whether C0 or C01 file exists.
+    """
+    manifest = full_manifest['data']
+    mouse_name = manifest['mouse_name']
+    base_path = Path(manifest['base_path'])
+    functional_plane = int(session['functional_plane'][0])
+
+    save_path = base_path / mouse_name / 'OUTPUT' / '2P' / 'cellpose'
+    save_path_registered = base_path / mouse_name / 'OUTPUT' / '2P' / 'registered'
+    save_path.mkdir(exist_ok=True, parents=True)
+    save_path_registered.mkdir(exist_ok=True, parents=True)
+
+    # Auto-detect channels if not specified (TIFF mode)
+    if channels_needed is None:
+        c01_file = save_path / f'lowres_meanImg_C01_plane{functional_plane}.tiff'
+        if c01_file.exists():
+            channels_needed = 'C01'
+        else:
+            channels_needed = 'C0'
+
     save_filename_C = save_path / f'lowres_meanImg_{channels_needed}_plane{functional_plane}.tiff'
     save_filename_rotated = save_path_registered / f'{save_filename_C.stem}_rotated.tiff'
 
@@ -99,8 +131,6 @@ def extract_suite2p_registered_planes(full_manifest: dict , session: dict, combi
         return
 
     # First-run detection: prompt only if NO rotated files exist yet for any plane.
-    # This way, once the user has gone through rotation setup once, all subsequent
-    # planes are processed silently (even if rotation is identity).
     rotation_config = get_rotation_config(full_manifest['params'])
     any_rotated_exists = any(save_path_registered.glob('*_rotated.tiff'))
 
@@ -121,7 +151,7 @@ def extract_suite2p_registered_planes(full_manifest: dict , session: dict, combi
         print(f'')
         print(f'    {reference_HCR_round}')
         print(f'')
-        print(f'  Then update rotation_2p_to_HCRspec in your manifest:')
+        print(f'  Then update rotation_2p_to_HCR in your manifest:')
         print(f'    {manifest_path}')
         print(f'')
         print(f'  Set "rotation" (degrees), "fliplr" (true/false), "flipud" (true/false)')

--- a/src/meta.py
+++ b/src/meta.py
@@ -25,6 +25,37 @@ def user_input_missing(check_results, message, color):
             if out=='y':
                 return
 
+def _validate_tiff_inputs(base_path, mouse_name, session, has_hires):
+    """Validate that expected TIFF files exist for TIFF input mode."""
+    # Get planes to process
+    if 'functional_planes' in session:
+        all_planes = list(session['functional_planes'])
+    elif 'functional_plane' in session:
+        all_planes = list(session['functional_plane'])
+    else:
+        raise ValueError("TIFF mode requires 'functional_planes' (or 'functional_plane') in session config.")
+
+    missing = []
+    output_base = base_path / mouse_name / 'OUTPUT' / '2P'
+
+    for plane in all_planes:
+        if has_hires:
+            expected = output_base / 'tile' / 'stitched' / f'hires_stitched_plane{plane}.tiff'
+            if not expected.exists():
+                missing.append(str(expected))
+        else:
+            c01 = output_base / 'cellpose' / f'lowres_meanImg_C01_plane{plane}.tiff'
+            c0 = output_base / 'cellpose' / f'lowres_meanImg_C0_plane{plane}.tiff'
+            if not c01.exists() and not c0.exists():
+                missing.append(f"{c0}  (green only)\n    or {c01}  (green+red)")
+
+    if missing:
+        msg = "TIFF input mode: missing required files. Place your images at:\n"
+        for m in missing:
+            msg += f"    {m}\n"
+        raise FileNotFoundError(msg)
+
+
 def verify_manifest(manifest, args):
     '''
     Verify that the json file is valid
@@ -32,11 +63,11 @@ def verify_manifest(manifest, args):
 
     if 'cellpose_channel' not in manifest['params']['HCR_cellpose']:
         raise ValueError("'cellpose_channel' must be specified in HCR_cellpose params. (e.g., 0 for first channel, 1 for second channel).")
-    
+
     if not args.only_hcr and '2p_cellpose' not in manifest['params']:
         raise ValueError("'2p_cellpose' configuration must be specified in params when processing 2P data.")
-            
-    
+
+
     manifest = manifest['data']
 
     # backward compat: accept old key name
@@ -52,8 +83,12 @@ def verify_manifest(manifest, args):
     if not args.only_hcr:
         assert 'two_photon_imaging' in manifest, "'two_photon_imaging' section required for full pipeline mode"
         assert len(manifest['two_photon_imaging']['sessions'])==1, 'only support one 2P sessions'
-        date_two_photons = manifest['two_photon_imaging']['sessions'][0]['date']
         session = manifest['two_photon_imaging']['sessions'][0]
+
+        # input_format: defaults to 'sbx' for backward compatibility with existing manifests
+        input_format = session.get('input_format', 'sbx')
+        if input_format not in ('sbx', 'tiff'):
+            raise ValueError(f"input_format must be 'sbx' or 'tiff', got '{input_format}'")
 
     #test that reference round exists
     reference_round = manifest['HCR_confocal_imaging']['reference_round']
@@ -62,43 +97,51 @@ def verify_manifest(manifest, args):
             break
     else:
         raise Exception(f"reference round was not found {reference_round} is not in rounds")
-    
-    # verify that all 2p runs exists.
+
     if not args.only_hcr:
-        check_results = []
-        for k in session:
-            if '_run' in k:
-                for run in session[k]:
-                    run_path_sbx = base_path / mouse_name / '2P' /  f'{mouse_name}_{date_two_photons}_{run}' / f'{mouse_name}_{date_two_photons}_{run}.sbx'
-                    check_results.append([run_path_sbx,os.path.exists(run_path_sbx)])
-        check_results = np.array(check_results)
-        user_input_missing(check_results, 'Some 2p runs are missing, do you whish to continue?', color='red')
+        if input_format == 'sbx':
+            # --- SBX validation (existing logic) ---
+            date_two_photons = session['date']
 
-        # verify that functional run exists.
-        suite2p_run = session['functional_run'][0]
-        suite2p_path = base_path / mouse_name / '2P' /  f'{mouse_name}_{date_two_photons}_{suite2p_run}' / 'suite2p' /'plane0/ops.npy'
-        user_input_missing(np.array([[suite2p_path, os.path.exists(suite2p_path)]]), 'Suite2p path is missing, do you wish to continue?', color='pink')
+            # verify that all 2p runs exists.
+            check_results = []
+            for k in session:
+                if '_run' in k:
+                    for run in session[k]:
+                        run_path_sbx = base_path / mouse_name / '2P' /  f'{mouse_name}_{date_two_photons}_{run}' / f'{mouse_name}_{date_two_photons}_{run}.sbx'
+                        check_results.append([run_path_sbx,os.path.exists(run_path_sbx)])
+            check_results = np.array(check_results)
+            user_input_missing(check_results, 'Some 2p runs are missing, do you whish to continue?', color='red')
 
-    # verify anatomical runs configuration
-    if not args.only_hcr:
-        has_lowres_green = len(session.get('anatomical_lowres_green_runs', [])) > 0
-        has_hires_green = len(session.get('anatomical_hires_green_runs', [])) > 0
+            # verify that functional run exists.
+            suite2p_run = session['functional_run'][0]
+            suite2p_path = base_path / mouse_name / '2P' /  f'{mouse_name}_{date_two_photons}_{suite2p_run}' / 'suite2p' /'plane0/ops.npy'
+            user_input_missing(np.array([[suite2p_path, os.path.exists(suite2p_path)]]), 'Suite2p path is missing, do you wish to continue?', color='pink')
 
-        if has_hires_green:
-            assert not has_lowres_green, "Cannot have both lowres and hires runs"
-            assert len(session['anatomical_hires_green_runs'])==len(session['anatomical_hires_red_runs']), "Number of hires green and red runs do not match"
-            has_hires = True
-        elif has_lowres_green:
-            assert len(session['anatomical_lowres_green_runs'])==len(session['anatomical_lowres_red_runs']), "Number of lowres green and red runs do not match"
-        # else: no anatomical runs — lowres mode using Suite2p mean image only
+            # verify anatomical runs configuration
+            has_lowres_green = len(session.get('anatomical_lowres_green_runs', [])) > 0
+            has_hires_green = len(session.get('anatomical_hires_green_runs', [])) > 0
 
-    # verify that unwarp_config exists (only needed for high-res workflow)
-    if has_hires and 'unwarp_config' in session:
-        if not os.path.exists(session['unwarp_config']):
-            new_path = base_path / 'Calibration_files_for_unwarping' / session['unwarp_config']
-            if not os.path.exists(new_path):
-                raise Exception(f"unwarp config file does not exist {session['unwarp_config']} and not in {new_path}")
-            session['unwarp_config'] = new_path
+            if has_hires_green:
+                assert not has_lowres_green, "Cannot have both lowres and hires runs"
+                assert len(session['anatomical_hires_green_runs'])==len(session['anatomical_hires_red_runs']), "Number of hires green and red runs do not match"
+                has_hires = True
+            elif has_lowres_green:
+                assert len(session['anatomical_lowres_green_runs'])==len(session['anatomical_lowres_red_runs']), "Number of lowres green and red runs do not match"
+            # else: no anatomical runs — lowres mode using Suite2p mean image only
+
+            # verify that unwarp_config exists (only needed for high-res workflow)
+            if has_hires and 'unwarp_config' in session:
+                if not os.path.exists(session['unwarp_config']):
+                    new_path = base_path / 'Calibration_files_for_unwarping' / session['unwarp_config']
+                    if not os.path.exists(new_path):
+                        raise Exception(f"unwarp config file does not exist {session['unwarp_config']} and not in {new_path}")
+                    session['unwarp_config'] = new_path
+
+        elif input_format == 'tiff':
+            # --- TIFF validation ---
+            has_hires = session.get('has_hires', False)
+            _validate_tiff_inputs(base_path, mouse_name, session, has_hires)
 
     return {'reference_round':reference_round, 'session':session}, has_hires
 

--- a/src/segmentation.py
+++ b/src/segmentation.py
@@ -8,7 +8,6 @@ import pandas as pd
 import scipy.io as sio
 from scipy.ndimage import median_filter as scipy_median_filter
 import pickle as pkl
-from suite2p.io import binary
 from scipy.sparse import csr_matrix
 from tifffile import imread as tif_imread
 from tifffile import imwrite as tif_imsave
@@ -17,7 +16,6 @@ from rich import print as rprint
 from scipy.spatial import ConvexHull
 from scipy.interpolate import LinearNDInterpolator
 from .registrations import verify_rounds
-from .functional import get_number_of_suite2p_planes
 from .meta import get_intensity_extraction_config, get_round_folder_name
 
 
@@ -425,9 +423,12 @@ def extract_probs_intensities(full_manifest):
 
 
 def extract_electrophysiology_intensities(full_manifest: dict , session: dict):
+    from suite2p.io import binary
+    from .functional import get_number_of_suite2p_planes
+
     rprint("[bold]Extract 2P Intensities[/bold]")
 
-    manifest = full_manifest['data'] 
+    manifest = full_manifest['data']
     mouse_name = manifest['mouse_name']
     date = session['date']
     suite2p_run = session['functional_run'][0]

--- a/src/tiling.py
+++ b/src/tiling.py
@@ -6,7 +6,11 @@ import cv2
 import hjson
 import numpy as np
 from rich import print as rprint
-from sbxreader import sbx_get_metadata, sbx_memmap
+try:
+    from sbxreader import sbx_get_metadata, sbx_memmap
+except ImportError:
+    sbx_get_metadata = None
+    sbx_memmap = None
 from tifffile import imread as tif_imread
 from tifffile import imwrite as tif_imwrite
 from .registrations import verify_rounds
@@ -146,7 +150,7 @@ def stitch_tiles_and_rotate(full_manifest: dict, session: dict):
     stitch the tiles of the session
     '''
     manifest = full_manifest['data']
-    if len(session['anatomical_hires_green_runs']) == 0:
+    if len(session.get('anatomical_hires_green_runs', [])) == 0 and session.get('input_format') != 'tiff':
         return
     tile_to_num = {'left':'001', 'center':'002', 'right':'003'}
     plane = session['functional_plane'][0]
@@ -176,7 +180,7 @@ def stitch_tiles_and_rotate(full_manifest: dict, session: dict):
         # Automated stitching workflow
         rprint("[bold cyan]Starting automated stitching...[/bold cyan]")
 
-        num_tiles = len(session['anatomical_hires_green_runs'])
+        num_tiles = len(session.get('anatomical_hires_green_runs', []))
 
         # Determine whether to use unwarped or warped tiles
         # Use unwarped if unwarp_config is specified (not empty string) and files exist


### PR DESCRIPTION
Users with pre-processed 2P mean images (from any microscope) can now run the pipeline by setting input_format: "tiff" in their manifest and placing TIFFs in the OUTPUT directory. SBX/Suite2p steps are skipped; sbxreader and suite2p imports are now optional.

- meta.py: input_format field (defaults to "sbx"), TIFF file validation
- master_pipeline.py: conditional process_plane(), skip electrophysiology
- functional.py: extract rotate_2p_plane() with auto-detect C0/C01
- tiling.py/segmentation.py: optional imports for TIFF-only installs
- New demo_tiff.hjson template, updated README with manifest guide