### PR TITLE
Cellpose 4 / SAM port, somaprint matcher, and 2P->HCR robustness

### DIFF
--- a/examples/demo.hjson
+++ b/examples/demo.hjson
@@ -93,6 +93,20 @@
             flipud: false      // mirror up-down after rotation
         }
 
+        // ----- 2P→HCR registration -----
+        // See agent_docs/parameter_tuning.md for the full tiered guide.
+        // Lower-tier knobs (RANSAC, FFT-IoU thresholds, etc.) are read from
+        // the same block but fall through to defaults when unset.
+        twop_to_hcr_registration: {
+            cascade_stages: [300, 100, 50]   // local tile sizes (px); [400, 200, 100] for sparse cells, [200, 100, 50] for dense
+            erosion: 2                       // 2P mask shrink (px); 0 for cp4-SAM masks, 3-4 for boundary artifacts
+            erosion_hcr: 0                   // HCR mask shrink (px); try 1 if HCR cells bleed
+            z_range_global: [-15, 15]        // z-offset search range (slices); widen to [-25, 25] for large z offset
+            xy_max_global: 500               // xy search range (px); raise to 600 if landmarks coarse / TPS loose
+            hull_margin: -100                // inward hull erosion (px, negative); less negative (-50) for poor landmark coverage
+            flip_z: false                    // true when HCR acquisition has inverted z-axis
+        }
+
         // ----- HCR cellpose (3D segmentation on registered stacks) -----
         HCR_cellpose: {
             model_path: "/path/to/your/cellpose_model"
@@ -126,6 +140,19 @@
         //     twop_to_hcr: "manual"      // "auto" = automated refinement (still needs initial landmarks)
         //     lowres_to_hires: "manual"   // "auto" = SIFT + RANSAC (no BigWarp needed)
         //     stitching: "manual"         // "auto" = SIFT + phase correlation
+        // }
+
+        // ----- Somaprint matcher (optional; defaults shown) -----
+        // Geometric 2P→HCR matcher (neighbor-vector fingerprint + GMM curation).
+        // Runs alongside the IoU best-match step and writes a parallel set of
+        // twoP_somaprint_* columns into the merged feature table. Set
+        // enabled: false to skip (saves ~2-3 min/plane); rest tunes the matcher.
+        // somaprint: {
+        //     enabled: true
+        //     lr_threshold: 0.05        // smaller = stricter confidence gate
+        //     // m_2p: 15, m_hcr: 30, n_pairs: 10, lambda_scale: 10.0,
+        //     // radius_factor: 3.0, max_rounds: 4, terminate_pct: 5.0,
+        //     // n_pairs_r2: 10, min_confirmed_for_round2: 5, min_cells_for_gmm: 30
         // }
 
         // ----- HCR registration selections -----

--- a/examples/demo_hires.hjson
+++ b/examples/demo_hires.hjson
@@ -69,6 +69,10 @@
             flipud: false
         }
 
+        twop_to_hcr_registration: {
+            cascade_stages: [300, 100, 50]
+        }
+
         HCR_cellpose: {
             model_path: "/path/to/your/cellpose_model"
             cellpose_channel: 0

--- a/examples/demo_standard.hjson
+++ b/examples/demo_standard.hjson
@@ -69,6 +69,10 @@
             flipud: false
         }
 
+        twop_to_hcr_registration: {
+            cascade_stages: [300, 100, 50]
+        }
+
         HCR_cellpose: {
             model_path: "/path/to/your/cellpose_model"
             cellpose_channel: 0

--- a/examples/param_example.hjson
+++ b/examples/param_example.hjson
@@ -9,3 +9,17 @@ HCR_selected_registrations:{
 
     ]
 }
+
+// 2P -> HCR registration: commonly tuned knobs.
+// Lower-tier params (RANSAC, FFT-IoU thresholds, coarse-match patches) are read
+// from this same block but fall through to defaults if not specified.
+// Full tiered guide: agent_docs/parameter_tuning.md.
+twop_to_hcr_registration:{
+    "cascade_stages":[400, 200, 100],   // strictly-decreasing tile sizes (px); default [300, 100, 50]
+    "erosion":2,                        // 2P mask shrink (px); 0 for cp4-SAM masks
+    "erosion_hcr":0,                    // HCR mask shrink (px); try 1 if HCR cells bleed
+    "z_range_global":[-15, 15],         // z-offset search range (slices); widen to [-25, 25] for large z offset
+    "xy_max_global":500,                // xy search range (px); raise to 600 if landmarks coarse
+    "hull_margin":-100,                 // inward hull erosion (px, negative); less negative (-50) for poor landmark coverage
+    "flip_z":false                      // true when HCR acquisition has inverted z-axis
+}

--- a/ezfish_all_cp4_environment_v2.yml
+++ b/ezfish_all_cp4_environment_v2.yml
@@ -1,0 +1,98 @@
+# ezfish_all_cp4 environment v2 — looser pins for fast solving
+# Identical to ezfish_all_environment_v2.yml except cellpose 4 (cellpose-SAM)
+# instead of cellpose 3. Use this when the fully-pinned cp4 yaml hits classic-
+# conda conflict-resolution hell. Trade-off: less reproducible pin set.
+#
+# USAGE:
+#   conda env create -f ezfish_all_cp4_environment_v2.yml -p /mnt/colab/shared_envs/ezfish_all_cp4
+#
+# BIGSTREAM: After creating, install bigstream:
+#   conda activate /mnt/colab/shared_envs/ezfish_all_cp4
+#   pip install -e /mnt/nasquatch/data/2p/jonna/Code_Python/Notebooks_Jonna/BigStream/bigstream_v2_andermann
+
+name: ezfish_all_cp4
+
+channels:
+  - conda-forge
+  - pytorch
+  - nvidia
+  - defaults
+
+dependencies:
+  - python=3.12
+
+  # Core scientific
+  - numpy>=1.26,<2
+  - scipy
+  - pandas
+  - scikit-image
+  - scikit-learn
+
+  # PyTorch with CUDA
+  - pytorch::pytorch=2.5
+  - pytorch::torchvision
+  - pytorch::torchaudio
+  - pytorch::pytorch-cuda=12.1
+
+  # Image I/O
+  - tifffile
+  - imagecodecs
+  - imageio
+  - pillow
+  - opencv
+
+  # Visualization
+  - matplotlib
+  - seaborn
+  - bokeh
+
+  # Interactive plotting (key for hcr_env functionality)
+  - ipympl
+  - ipywidgets
+
+  # Jupyter
+  - jupyterlab
+  - ipykernel
+
+  # Data formats
+  - zarr
+  - h5py
+  - numcodecs
+
+  # Parallel/distributed
+  - dask
+  - distributed
+  - dask-jobqueue
+  - numba
+
+  # Utilities
+  - tqdm
+  - rich
+  - natsort
+  - pyyaml
+  - joblib
+
+  # GUI
+  - pyqt
+
+  # Pip packages
+  - pip
+  - pip:
+    - simpleitk==2.3.1
+    - cellpose>=4.0.0
+    - suite2p>=0.14.4
+    - git+https://github.com/GFleishman/ClusterWrap.git@fa718ac49
+    - sbxreader
+    - roifile
+    - pystackreg>=0.2.7
+    - umap-learn
+    - statsmodels
+    - plotly
+    - xgboost
+    - fastremap
+    - fishspot>=0.3.0
+    - morphsnakes
+    - pynrrd
+    - pydantic>=2.7
+    - flatten_json
+    - hjson

--- a/master_pipeline.py
+++ b/master_pipeline.py
@@ -1,12 +1,12 @@
 import argparse
 from pathlib import Path
-from rich import print as rprint
 from src import functional as fc
 from src import tiling as tl
 from src import registrations as rf
 from src import registrations_landmarks as rf_landmarks
 from src import meta as mt
 from src import segmentation as sg
+from src.meta import rprint
 
 # This is the main pipeline script that runs the entire pipeline
 
@@ -116,7 +116,12 @@ def main(args = None):
             # Determine if this is the reference plane
             plane_reference = None if plane == reference_plane else reference_plane
             sg.align_masks(full_manifest, session, only_hcr=args.only_hcr, reference_plane=plane_reference)
+            # Augment IoU CSV with somaprint columns (geometric matcher,
+            # parallel to IoU; no-op if disabled in manifest).
+            sg.align_somaprint(full_manifest, session, only_hcr=args.only_hcr)
             sg.merge_masks(full_manifest, session, only_hcr=args.only_hcr)
+
+        sg.print_match_summary(full_manifest, all_planes)
 
         rprint('\n' + '='*80)
         rprint('[bold green]Pipeline completed successfully for all planes![/bold green]')

--- a/src/analysis_utils.py
+++ b/src/analysis_utils.py
@@ -735,13 +735,24 @@ def subtract_neuropil_with_qc(
     return original_df, subtracted_df, unclipped_df
 
 
-def select_best_match(group: pd.DataFrame) -> pd.Series:
+def _best_match_score_col(df: pd.DataFrame) -> str:
     """
-    Select the row with highest IoU from a group.
+    Choose which IoU column to rank 2P matches by.
 
-    Helper function for deduplication.
+    Current schema: `twoP_iou` is the plane-restricted (fair) IoU.
+    Legacy `twoP_iou_at_z` is accepted as an alias for any
+    pre-rename tables still floating around. Raises if neither is present.
     """
-    return group.loc[group['twoP_iou'].idxmax()]
+    if 'twoP_iou' in df.columns:
+        return 'twoP_iou'
+    if 'twoP_iou_at_z' in df.columns:
+        return 'twoP_iou_at_z'
+    raise KeyError("neither 'twoP_iou' nor 'twoP_iou_at_z' found in DataFrame")
+
+
+def select_best_match(group: pd.DataFrame) -> pd.Series:
+    """Select the row with the highest IoU (twoP_iou) from a group."""
+    return group.loc[group[_best_match_score_col(group)].idxmax()]
 
 
 def deduplicate_2p_matches(df: pd.DataFrame) -> pd.DataFrame:
@@ -749,10 +760,10 @@ def deduplicate_2p_matches(df: pd.DataFrame) -> pd.DataFrame:
     Keep only the best HCR-to-2P match per 2P cell.
 
     When multiple HCR cells match the same 2P cell (twoP_mask column),
-    keep the one with highest twoP_iou.
+    keep the one with the highest IoU (twoP_iou).
 
     Args:
-        df: DataFrame with 'twoP_mask' and 'twoP_iou' columns
+        df: DataFrame with 'twoP_mask' and an IoU column
 
     Returns:
         Deduplicated DataFrame
@@ -762,8 +773,10 @@ def deduplicate_2p_matches(df: pd.DataFrame) -> pd.DataFrame:
         rprint("[yellow]Warning: 'twoP_mask' column not found, skipping deduplication[/yellow]")
         return df
 
-    if 'twoP_iou' not in df.columns:
-        rprint("[yellow]Warning: 'twoP_iou' column not found, skipping deduplication[/yellow]")
+    try:
+        _best_match_score_col(df)
+    except KeyError:
+        rprint("[yellow]Warning: no twoP_iou(_at_z) column found, skipping deduplication[/yellow]")
         return df
 
     # Filter to only cells with 2P matches
@@ -828,7 +841,7 @@ def smart_merge_planes(
     reference_plane: int,
     mask_id_col: str = 'mask_id_main',
     twop_mask_col: str = 'twoP_mask',
-    twop_iou_col: str = 'twoP_iou',
+    twop_iou_col: str = None,
     hcr_coords: pd.DataFrame = None
 ) -> pd.DataFrame:
     """
@@ -847,7 +860,10 @@ def smart_merge_planes(
         reference_plane: The reference/functional plane number
         mask_id_col: Column name for HCR cell ID
         twop_mask_col: Column name for 2P mask ID
-        twop_iou_col: Column name for IoU score
+        twop_iou_col: Column name for IoU score used for tiebreaking. When
+                      None (default), uses 'twoP_iou_at_z' if present (the
+                      fair z-restricted IoU), else falls back to 'twoP_iou'
+                      (legacy 3D-symmetric IoU).
         hcr_coords: Optional DataFrame with HCR coordinates (from load_hcr_coordinates)
                     with columns: mask_id, hcr_x, hcr_y, hcr_z
 
@@ -873,6 +889,8 @@ def smart_merge_planes(
     # Find actual column names
     mask_col = get_col(combined, mask_id_col)
     twop_col = get_col(combined, twop_mask_col)
+    if twop_iou_col is None:
+        twop_iou_col = _best_match_score_col(combined)
     iou_col = get_col(combined, twop_iou_col)
 
     rprint(f"  Starting smart merge: {len(combined)} rows from {len(plane_dfs)} planes")

--- a/src/auto_stitching.py
+++ b/src/auto_stitching.py
@@ -28,7 +28,11 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 from tqdm import tqdm
-from rich import print as rprint
+
+try:
+    from .meta import rprint  # Relative import (running as part of a package)
+except ImportError:
+    from meta import rprint  # Absolute import (running in Jupyter notebook)
 
 
 class StitchingError(Exception):
@@ -255,11 +259,10 @@ def compute_pairwise_shifts(
     z_planes: List[int],
     overlap_fraction: float = 0.40,
     noise_floor: float = 15.0,
+    stitch_channel: int = 0,
 ) -> Tuple[Dict[Tuple[int, int], Dict], Dict[Tuple[int, int], Dict[int, Dict]]]:
     """
     Compute pairwise shifts for all tile pairs across all z-planes.
-
-    Uses channel 0 (green/GCaMP) for registration.
 
     Args:
         tile_data: Dict mapping tile number to data array (Z, C, Y, X)
@@ -267,6 +270,8 @@ def compute_pairwise_shifts(
         z_planes: List of z-plane indices
         overlap_fraction: Expected overlap as fraction of tile width (from config)
         noise_floor: Minimum pixel value to consider as signal
+        stitch_channel: Which channel of tile_data to use for cross-correlation
+            (default 0 = green; set to 1 for mice with PMT0 off / single-PMT red)
 
     Returns:
         consensus_shifts: Dict with mean shift across z-planes
@@ -283,8 +288,8 @@ def compute_pairwise_shifts(
     expected_dx = int(tile_width * (1 - overlap_fraction))
 
     for t1, t2 in tqdm(pairs, desc=f"Aligning {len(pairs)} tile pairs"):
-        data1 = tile_data[t1][:, 0, :, :]  # Channel 0
-        data2 = tile_data[t2][:, 0, :, :]
+        data1 = tile_data[t1][:, stitch_channel, :, :]
+        data2 = tile_data[t2][:, stitch_channel, :, :]
 
         shifts_by_z = {}
 
@@ -510,7 +515,8 @@ def auto_stitch_tiles(
     overlap_fraction: float = 0.40,
     noise_floor: float = 15.0,
     min_signal_frac: float = 0.01,
-    upsample_factor: int = 10
+    upsample_factor: int = 10,
+    stitch_channel: int = 0,
 ) -> np.ndarray:
     """
     Main entry point for automated tile stitching.
@@ -524,6 +530,8 @@ def auto_stitch_tiles(
         noise_floor: Minimum pixel value for signal
         min_signal_frac: (unused, for API compatibility)
         upsample_factor: (unused, for API compatibility)
+        stitch_channel: Channel of the warped tiles used for cross-correlation
+            (default 0; set to 1 when PMT0 is off so ch0 has no signal).
 
     Returns:
         Stitched volume (Z, C, Y, X)
@@ -564,7 +572,8 @@ def auto_stitch_tiles(
     pairs = find_horizontal_pairs(num_tiles)
 
     consensus_shifts, per_plane_shifts = compute_pairwise_shifts(
-        tile_data, pairs, z_planes, overlap_fraction, noise_floor
+        tile_data, pairs, z_planes, overlap_fraction, noise_floor,
+        stitch_channel=stitch_channel,
     )
 
     # Compute positions

--- a/src/automation.py
+++ b/src/automation.py
@@ -5,8 +5,11 @@ Keeps it simple: ~100 lines, no classes, reuse existing patterns.
 
 import pandas as pd
 from pathlib import Path
-from rich import print as rprint
-from rich.prompt import Prompt
+
+try:
+    from .meta import rprint, Prompt  # Relative import (running as part of a package)
+except ImportError:
+    from meta import rprint, Prompt  # Absolute import (running in Jupyter notebook)
 
 
 def find_landmark_file(base_dir, plane, prefix="", suffix="_landmarks.csv", hcr_ref="1"):
@@ -161,9 +164,9 @@ def prompt_registration_checkpoint(qa_paths, auto_landmarks_path, step_name, pla
     rprint(f"  [yellow]{auto_landmarks_path}[/yellow]")
 
     rprint("\n[bold]After checking QA images, choose:[/bold]")
-    rprint("  [green][y][/green] Accept - continue with auto results")
-    rprint("  [yellow][r][/yellow] Refine - edit landmarks_auto.csv in BigWarp, then re-run")
-    rprint("  [red][n][/red] Skip - skip this plane, continue with others\n")
+    rprint("  \\[[green]y[/green]] Accept - continue with auto results")
+    rprint("  \\[[yellow]r[/yellow]] Refine - edit landmarks_auto.csv in BigWarp, then re-run")
+    rprint("  \\[[red]n[/red]] Skip - skip this plane, continue with others\n")
 
     choice = Prompt.ask("Your choice", choices=["y", "r", "n"], default="y")
 

--- a/src/functional.py
+++ b/src/functional.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 
 import numpy as np
-from rich import print as rprint
-from rich.progress import track
 from skimage.transform import rotate
-from .registrations import verify_rounds
-from .meta import check_rotation, get_rotation_config, parse_json, output_root
+try:
+    from .registrations import verify_rounds  # Relative import (running as part of a package)
+    from .meta import check_rotation, get_rotation_config, parse_json, output_root, rprint, track
+except ImportError:
+    from registrations import verify_rounds  # Absolute import (running in Jupyter notebook)
+    from meta import check_rotation, get_rotation_config, parse_json, output_root, rprint, track
 from tifffile import imread as tif_imread
 from tifffile import imwrite as tif_imwrite
 from sbxreader import sbx_get_metadata, sbx_memmap

--- a/src/functional.py
+++ b/src/functional.py
@@ -5,7 +5,7 @@ from rich import print as rprint
 from rich.progress import track
 from skimage.transform import rotate
 from .registrations import verify_rounds
-from .meta import check_rotation, get_rotation_config, parse_json
+from .meta import check_rotation, get_rotation_config, parse_json, output_root
 from tifffile import imread as tif_imread
 from tifffile import imwrite as tif_imwrite
 from sbxreader import sbx_get_metadata, sbx_memmap
@@ -73,8 +73,8 @@ def prepare_tiff_input(full_manifest: dict, session: dict):
 
     src_path = base_path / mouse_name / '2P' / f'plane_{functional_plane}.tiff'
     hires_src = base_path / mouse_name / '2P' / f'plane_{functional_plane}_hires.tiff'
-    save_path = base_path / mouse_name / 'OUTPUT' / '2P' / 'cellpose'
-    save_path_registered = base_path / mouse_name / 'OUTPUT' / '2P' / 'registered'
+    save_path = output_root(full_manifest) / '2P' / 'cellpose'
+    save_path_registered = output_root(full_manifest) / '2P' / 'registered'
     save_path.mkdir(exist_ok=True, parents=True)
     save_path_registered.mkdir(exist_ok=True, parents=True)
 
@@ -132,8 +132,8 @@ def prepare_suite2p_input(full_manifest: dict, session: dict):
     functional_plane = int(session['functional_plane'][0])
 
     suite2p_path = base_path / mouse_name / '2P' / 'suite2p'
-    save_path = base_path / mouse_name / 'OUTPUT' / '2P' / 'cellpose'
-    save_path_registered = base_path / mouse_name / 'OUTPUT' / '2P' / 'registered'
+    save_path = output_root(full_manifest) / '2P' / 'cellpose'
+    save_path_registered = output_root(full_manifest) / '2P' / 'registered'
     save_path.mkdir(exist_ok=True, parents=True)
     save_path_registered.mkdir(exist_ok=True, parents=True)
 
@@ -235,8 +235,8 @@ def extract_suite2p_registered_planes(full_manifest: dict , session: dict, combi
     base_path = Path(manifest['base_path'])
 
     suite2p_path = base_path / mouse_name / '2P' /  f'{mouse_name}_{date}_{suite2p_run}' / 'suite2p'
-    save_path = base_path / mouse_name / 'OUTPUT' / '2P' / 'cellpose'
-    save_path_registered = base_path / mouse_name / 'OUTPUT' / '2P' / 'registered'
+    save_path = output_root(full_manifest) / '2P' / 'cellpose'
+    save_path_registered = output_root(full_manifest) / '2P' / 'registered'
 
     save_path.mkdir(exist_ok=True, parents=True)
     save_path_registered.mkdir(exist_ok=True, parents=True)

--- a/src/meta.py
+++ b/src/meta.py
@@ -3,27 +3,47 @@ import sys
 import hjson
 import numpy as np
 from pathlib import Path
-from rich.prompt import Prompt
+
+# Rich-compat shim. All pipeline modules import rprint / track / Prompt from
+# here so the fallback lives in one place. If rich isn't installed (e.g. a
+# stripped-down notebook env), modules still import cleanly and lose only
+# the Rich markup formatting.
+try:
+    from rich import print as rprint
+    from rich.progress import track
+    from rich.prompt import Prompt
+except ImportError:
+    rprint = print
+
+    def track(iterable, *args, **kwargs):
+        return iterable
+
+    class Prompt:
+        @staticmethod
+        def ask(prompt, choices=None, default=None, **kwargs):
+            ans = input(str(prompt) + ' ').strip()
+            if not ans and default is not None:
+                return default
+            return ans
 
 
 def parse_json(json_file):
     """
-    Parse a json file and return a dictionary object
+    Parse a json/hjson manifest. Normalizes base_path slashes so the same
+    manifest works whether loaded on Linux (/mnt/...) or Windows (\\...).
     """
     with open(json_file, 'r') as f:
-        return hjson.load(f)
+        manifest = hjson.load(f)
+    bp = manifest.get('data', {}).get('base_path')
+    if isinstance(bp, str):
+        manifest['data']['base_path'] = bp.replace('\\', '/')
+    return manifest
 
 
 def output_root(full_manifest) -> Path:
-    """Pipeline OUTPUT directory: base_path / mouse_name / OUTPUT{output_dir_suffix}.
-
-    Honors params.output_dir_suffix so cp4-eval (or any future what-if run) can
-    write to OUTPUT_cp4/ without overwriting the cp3 OUTPUT/ baseline. Default
-    suffix is empty, preserving existing behavior for every existing manifest.
-    """
+    """Pipeline OUTPUT directory: base_path / mouse_name / OUTPUT."""
     data = full_manifest['data']
-    suffix = full_manifest.get('params', {}).get('output_dir_suffix', '')
-    return Path(data['base_path']) / data['mouse_name'] / f'OUTPUT{suffix}'
+    return Path(data['base_path']) / data['mouse_name'] / 'OUTPUT'
     
 def user_input_missing(check_results, message, color):
     if  (np.array(check_results)[:,1]==False).any():

--- a/src/meta.py
+++ b/src/meta.py
@@ -12,6 +12,18 @@ def parse_json(json_file):
     """
     with open(json_file, 'r') as f:
         return hjson.load(f)
+
+
+def output_root(full_manifest) -> Path:
+    """Pipeline OUTPUT directory: base_path / mouse_name / OUTPUT{output_dir_suffix}.
+
+    Honors params.output_dir_suffix so cp4-eval (or any future what-if run) can
+    write to OUTPUT_cp4/ without overwriting the cp3 OUTPUT/ baseline. Default
+    suffix is empty, preserving existing behavior for every existing manifest.
+    """
+    data = full_manifest['data']
+    suffix = full_manifest.get('params', {}).get('output_dir_suffix', '')
+    return Path(data['base_path']) / data['mouse_name'] / f'OUTPUT{suffix}'
     
 def user_input_missing(check_results, message, color):
     if  (np.array(check_results)[:,1]==False).any():

--- a/src/processing_notebooks/HCR_rounds/reg_imports.py
+++ b/src/processing_notebooks/HCR_rounds/reg_imports.py
@@ -20,7 +20,7 @@ if _src_path not in sys.path:
     sys.path.insert(0, _src_path)
 
 from registrations import (HCR_confocal_imaging,
-                                 verify_rounds)
+                                 verify_rounds, parse_json)
 from bigstream_functions import custom_easifish_registration_pipeline, register_lowres, get_registration_score
 # Path for bigstream unless you did pip install
 sys.path = [fr"\\nasquatch\data\2p\jonna\Code_Python\Notebooks_Jonna\BigStream\bigstream_v2_andermann"] + sys.path 

--- a/src/registrations.py
+++ b/src/registrations.py
@@ -8,10 +8,10 @@ import numpy as np
 from pathlib import Path
 
 try:
-    from .meta import parse_json, get_hcr_to_hcr_registration_config, get_rotation_config  # Relative import (for running as part of a package)
+    from .meta import parse_json, get_hcr_to_hcr_registration_config, get_rotation_config, rprint, track  # Relative import (for running as part of a package)
     from . import automation as auto
 except ImportError:
-    from meta import parse_json, get_hcr_to_hcr_registration_config, get_rotation_config  # Absolute import (for running in Jupyter Notebook)
+    from meta import parse_json, get_hcr_to_hcr_registration_config, get_rotation_config, rprint, track  # Absolute import (for running in Jupyter Notebook)
     import automation as auto
 
 try:
@@ -27,6 +27,7 @@ try:
         build_z_quad_blend, extract_centroids, find_cell_displacements,
         fit_affine_ransac, run_local_tile_ransac,
         compute_tile_defaults, compute_adaptive_matching_params,
+        resolve_hcr_resolution,
     )
 except ImportError:
     from registrations_utils import (
@@ -39,12 +40,11 @@ except ImportError:
         build_z_quad_blend, extract_centroids, find_cell_displacements,
         fit_affine_ransac, run_local_tile_ransac,
         compute_tile_defaults, compute_adaptive_matching_params,
+        resolve_hcr_resolution,
     )
 import pandas as pd
 
-from rich.progress import track
 import SimpleITK as sitk
-from rich import print as rprint
 from tifffile import imwrite as tif_imwrite
 from tifffile import imread as tif_imread
 # RBFInterpolator/griddata now handled in registrations_utils.py
@@ -57,7 +57,10 @@ sys.path = ["/mnt/nasquatch/data/2p/jonna/Code_Python/Notebooks_Jonna/BigStream/
 
 from bigstream.piecewise_transform import distributed_apply_transform
 
-from .meta import output_root
+try:
+    from .meta import output_root
+except ImportError:
+    from meta import output_root
 
 
 def _resolve_hcr_path(expected_path: Path) -> Path:
@@ -545,15 +548,19 @@ def register_lowres_to_hires(full_manifest, session):
         if tile_refinement_enabled:
             scale_factor = hires_2d.shape[0] / lowres_2d.shape[0]
 
-            # Adaptive tile size: smaller tiles for higher scale factors
-            # At 2x scale, 300px lores = 600px hires tiles (original behavior)
-            # At 4.5x scale, 100px lores = 454px hires tiles (finer granularity needed)
-            tile_size_lores = 300 if scale_factor < 3.0 else 100
+            # Tile size in lowres pixels. Bigger tiles → more SIFT features per tile
+            # → more robust fits, especially at edges. 200 lowres ≈ 700-900 hires
+            # at typical scale factors (3-4.5x), still fine-grained enough to
+            # capture local nonlinear distortion.
+            tile_size_lores = sift_config.get('tile_size_lores', 200)
             tile_size_hires = int(tile_size_lores * scale_factor)
 
             tile_config = {
-                'tile_size': tile_size_hires, 'tile_overlap': 0.3, 'blend_width': 10, 'max_shift': 40,
-                'n_features': 100, 'min_matches': 3, 'ratio_threshold': 0.8, 'ransac_reproj_threshold': 5.0,
+                'tile_size': tile_size_hires, 'tile_overlap': 0.3, 'blend_width': 10,
+                'max_shift': max(60, int(tile_size_hires * 0.20)),
+                'scale_tol': 0.35,
+                'n_features': sift_config.get('tile_n_features', 500),  # was 100, bumped to handle bigger tiles
+                'min_matches': 3, 'ratio_threshold': 0.8, 'ransac_reproj_threshold': 5.0,
                 'min_feature_size': 8, 'max_spatial_distance': 0,
                 'percentile_norm': (2, 98),
                 'require_ncc_improvement': False, 'min_overlap_fraction': 0.3,
@@ -662,10 +669,13 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
     QUAD_BLEND_DIST = reg_params.get('quad_blend_dist', 300)
     FOV_CROP_MARGIN = reg_params.get('fov_crop_margin', 150)
 
-    # Single affine: coarse matching + RANSAC (v13: single pass is sufficient)
-    PATCH_RADIUS_COARSE = reg_params.get('patch_radius_coarse', 120)
-    SEARCH_XY_COARSE = reg_params.get('search_xy_coarse', 150)
-    SEARCH_Z_COARSE = reg_params.get('search_z_coarse', 9)
+    # Single affine: coarse matching + RANSAC (v13: single pass is sufficient).
+    # Defaults bumped 2026-06-02 after SRC110 plane 2 showed P95 |dz|=9 saturating the
+    # old +/-9 cap and P95 XY=129 hitting the old +/-115 effective cap (patch=240 clipped
+    # requested 150 down to 115). New defaults give the affine ~+/-180 XY / +/-12 Z effective.
+    PATCH_RADIUS_COARSE = reg_params.get('patch_radius_coarse', 185)
+    SEARCH_XY_COARSE = reg_params.get('search_xy_coarse', 175)
+    SEARCH_Z_COARSE = reg_params.get('search_z_coarse', 12)
 
     # Per-cell FFT-IoU settings
     MIN_PEAK_RATIO = reg_params.get('min_peak_ratio', 1.02)
@@ -682,20 +692,35 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
     RANSAC_MIN_SAMPLES = reg_params.get('ransac_min_samples', 6)
     RANSAC_MAX_TRIALS = reg_params.get('ransac_max_trials', 2000)
 
-    # Adaptive cascade parameters (v13)
-    SEARCH_XY_PERCENTILE = reg_params.get('search_xy_percentile', 95)
-    SEARCH_XY_MULTIPLIER = reg_params.get('search_xy_multiplier', 1.5)
-    SEARCH_XY_TILE_RATIO = reg_params.get('search_xy_tile_ratio', 0.3)
-    PATCH_SEARCH_RATIO = reg_params.get('patch_search_ratio', 2.0)
-    PATCH_TILE_RATIO = reg_params.get('patch_tile_ratio', 0.6)
-    SEARCH_XY_MIN = reg_params.get('search_xy_min', 3)
-    SEARCH_XY_MAX = reg_params.get('search_xy_max', 50)
-    SEARCH_Z_DEFAULT = reg_params.get('search_z_default', 2)
-    SEARCH_Z_CASCADE_FINE = reg_params.get('search_z_cascade_fine', 1)
-
     # Local tile cascade: auto-computed defaults, configurable stages
     CASCADE_STAGES = reg_params.get('cascade_stages', [300, 100, 50])
+    if not (isinstance(CASCADE_STAGES, list) and len(CASCADE_STAGES) >= 1
+            and all(isinstance(s, int) and s > 0 for s in CASCADE_STAGES)
+            and all(a > b for a, b in zip(CASCADE_STAGES, CASCADE_STAGES[1:]))):
+        raise ValueError(
+            "params.twop_to_hcr_registration.cascade_stages must be a non-empty "
+            f"list of strictly-decreasing positive integers; got {CASCADE_STAGES!r}")
     TILE_DEFAULTS = {ts: compute_tile_defaults(ts) for ts in CASCADE_STAGES}
+
+    # Cascade per-tile search sizing (manifest-overridable presets):
+    # XY_TILE_RATIO    : stage-0 search_xy = tile_size * ratio; also caps stages 1+
+    # Z_TILE_RATIO     : stage-0 search_z  = max(SEARCH_Z_MIN, round(tile_size * ratio))
+    # SEARCH_Z_MIN/MAX : floor (stage 0) and cap (stages 1+) for per-tile Z search
+    XY_TILE_RATIO = reg_params.get('xy_tile_ratio', 0.4)
+    Z_TILE_RATIO  = reg_params.get('z_tile_ratio',  0.01)
+    SEARCH_Z_MIN  = reg_params.get('search_z_min',  2)
+    SEARCH_Z_MAX  = reg_params.get('search_z_max',  8)
+
+    # Edge-correction knobs for per-tile warp synthesis. Defaults preserve the
+    # historical "snap to zero outside data envelope" behavior; set
+    # use_nn_fallback=True to bleed to nearest-tile shift instead, eliminating
+    # the rigid warp front at the FOV edge (Voronoi seams are bounded by the
+    # per-tile IoU + MAD validation the accepted tiles already passed).
+    USE_NN_FALLBACK        = bool(reg_params.get('use_nn_fallback', False))
+    DATA_SIGMA_MULT        = float(reg_params.get('data_sigma_mult', 1.0))
+    BORDER_DECAY_MULT      = float(reg_params.get('border_decay_mult', 2.0))
+    BORDER_WEIGHT_FLOOR    = float(reg_params.get('border_weight_floor', 0.0))
+    DISABLE_BORDER_ANCHORS = bool(reg_params.get('disable_border_anchors', False))
 
     # Print configuration (compact)
     rprint(f"[dim]Parameters: erosion={EROSION}, Z={Z_RANGE_GLOBAL}, "
@@ -804,8 +829,10 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
     output_folder.mkdir(parents=True, exist_ok=True)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Load and prepare reference landmarks (HCR resolution from manifest)
-    hcr_resolution = full_manifest['data']['HCR_confocal_imaging']['rounds'][0]['resolution']
+    # HCR resolution: TIFF metadata is the source of truth; manifest entry is an
+    # optional override that emits a loud warning on mismatch.
+    manifest_resolution = full_manifest['data']['HCR_confocal_imaging']['rounds'][0].get('resolution')
+    hcr_resolution = resolve_hcr_resolution(hcr_ref_round_path, manifest_resolution)
     landmarks_df = load_landmarks(landmarks_path, hcr_resolution)
     rprint(f"[dim]Loaded {len(landmarks_df)} landmarks[/dim]")
 
@@ -967,6 +994,21 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
         df_coarse = pd.DataFrame(cell_results_coarse)
         ny_c, nx_c = twop_crop_binary.shape
 
+        # DIAGNOSTIC: per-cell residual distribution from the affine matcher (pre-RANSAC).
+        # Tells us whether the affine search window was the bottleneck (P95 saturated near
+        # SEARCH_XY_COARSE/SEARCH_Z_COARSE) or whether residuals are small and the weak
+        # affine fit is a model-mismatch problem (P95 << search window).
+        if len(df_coarse) > 0:
+            _hc = df_coarse[df_coarse.peak_ratio >= MIN_PEAK_RATIO]
+            if len(_hc) > 0:
+                _resid_xy = np.sqrt(_hc.dy.values**2 + _hc.dx.values**2)
+                _resid_z = np.abs(_hc.dz.values)
+                rprint(f"  [dim]Post-global per-cell residuals (n={len(_hc)}): "
+                       f"XY P50={np.median(_resid_xy):.0f}px / P95={np.percentile(_resid_xy, 95):.0f}px"
+                       f" (search +/-{SEARCH_XY_COARSE}px), "
+                       f"|dz| P50={np.median(_resid_z):.1f} / P95={np.percentile(_resid_z, 95):.1f}"
+                       f" (search +/-{SEARCH_Z_COARSE})[/dim]")
+
         # Filter and fit RANSAC
         df_A = df_coarse[df_coarse.peak_ratio >= MIN_PEAK_RATIO].copy()
         df_A = df_A[df_A.cell_iou > 0.0]
@@ -1047,26 +1089,17 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
             td = TILE_DEFAULTS[tile_size]
             prev_iou = cascade_state['iou']
 
-            # Skip later stages if previous stage did not improve over affine
-            if prev_iou <= iou_affine and tile_size != CASCADE_STAGES[0]:
-                rprint(f"  [dim]Skipping {tile_size}px tiles (no improvement from previous stage)[/dim]")
-                continue
+            # Stages run independently — each attempts from the current state and
+            # reverts itself if IoU drops. Don't skip based on prior-stage outcome.
 
-            # Compute adaptive matching params (v13)
-            if _si == 0 or df_post_rematch is None:
-                # First stage: tile-proportional defaults
-                patch_r = int(tile_size * PATCH_TILE_RATIO)
-                search_xy = int(tile_size * SEARCH_XY_TILE_RATIO)
-                search_z = SEARCH_Z_DEFAULT
-            else:
-                # Subsequent stages: adaptive from post-correction residuals
-                patch_r, search_xy, search_z = compute_adaptive_matching_params(
-                    df_post_rematch, tile_size, stage_idx=_si,
-                    percentile=SEARCH_XY_PERCENTILE, multiplier=SEARCH_XY_MULTIPLIER,
-                    tile_ratio=SEARCH_XY_TILE_RATIO, patch_ratio=PATCH_SEARCH_RATIO,
-                    patch_tile_ratio=PATCH_TILE_RATIO,
-                    search_xy_min=SEARCH_XY_MIN, search_xy_max=SEARCH_XY_MAX,
-                    search_z_default=SEARCH_Z_DEFAULT, search_z_fine=SEARCH_Z_CASCADE_FINE)
+            # Compute adaptive matching params (v13).
+            # Function returns tile-proportional defaults when stage_idx==0
+            # or cell_df is empty; adaptive residual-based sizing otherwise.
+            patch_r, search_xy, search_z = compute_adaptive_matching_params(
+                df_post_rematch if df_post_rematch is not None else pd.DataFrame(),
+                tile_size, stage_idx=_si,
+                tile_ratio=XY_TILE_RATIO, z_tile_ratio=Z_TILE_RATIO,
+                search_z_min=SEARCH_Z_MIN, search_z_max=SEARCH_Z_MAX)
 
             rprint(f"  [dim]Tiles {tile_size}px: {2 * patch_r}px patches, +/-{search_xy}px search, z+/-{search_z}[/dim]")
             centroids_cur = extract_centroids(cascade_state['twop_labels'])
@@ -1095,7 +1128,12 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
                 min_cells_affine=td.get('min_cells_affine', 3),
                 min_iou=MIN_IOU_LOCAL, min_gain=MIN_GAIN_LOCAL,
                 border_anchor_spacing=td['border_spacing'],
-                smoothing=td['rbf_smoothing'])
+                smoothing=td['rbf_smoothing'],
+                use_nn_fallback=USE_NN_FALLBACK,
+                data_sigma_mult=DATA_SIGMA_MULT,
+                border_decay_mult=BORDER_DECAY_MULT,
+                border_weight_floor=BORDER_WEIGHT_FLOOR,
+                disable_border_anchors=DISABLE_BORDER_ANCHORS)
 
             # Displacement clamping
             _accepted = [t for t in tile_res if t['accepted']]
@@ -1150,20 +1188,28 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
             # Post-correction re-match: measure actual remaining residuals
             # This feeds accurate adaptive params to the next cascade stage.
             if _si < len(CASCADE_STAGES) - 1:  # no need after last stage
-                _rematch_search = max(SEARCH_XY_MIN, min(15, int(tile_size * 0.3)))
+                _rematch_search = max(3, min(15, int(tile_size * 0.3)))
                 _rematch_patch = max(_rematch_search + 5, _rematch_search * 2)
+                # search_z >= SEARCH_Z_MAX so the rematch can actually measure residual
+                # z-curvature; otherwise the next stage's adaptive search_z saturates at
+                # whatever the rematch could see (was hardcoded =1, which masked all real
+                # z residual and pinned subsequent stages to z+/-1).
+                _rematch_search_z = max(2, SEARCH_Z_MAX)
                 _rematch_results = find_cell_displacements(
                     cascade_state['twop_binary'], cascade_state['twop_labels'],
                     hcr_crop_3d, cascade_state['z_map'], centroids_cur,
                     patch_radius=_rematch_patch, search_xy=_rematch_search,
-                    search_z=SEARCH_Z_CASCADE_FINE, fov_dilation=FOV_DILATION,
+                    search_z=_rematch_search_z, fov_dilation=FOV_DILATION,
                     min_peak_ratio=MIN_PEAK_RATIO)
                 df_post_rematch = pd.DataFrame(_rematch_results)
                 df_post_rematch = df_post_rematch[df_post_rematch.peak_ratio >= MIN_PEAK_RATIO].copy()
                 if len(df_post_rematch) > 0:
                     _post_resid = np.sqrt(df_post_rematch.dy.values**2 + df_post_rematch.dx.values**2)
-                    rprint(f"  [dim]Post-correction residuals: median={np.median(_post_resid):.1f}px, "
-                           f"P95={np.percentile(_post_resid, 95):.1f}px[/dim]")
+                    _post_dz = np.abs(df_post_rematch.dz.values)
+                    rprint(f"  [dim]Post-correction residuals: "
+                           f"XY median={np.median(_post_resid):.1f}px / P95={np.percentile(_post_resid, 95):.1f}px, "
+                           f"|dz| median={np.median(_post_dz):.1f} / P95={np.percentile(_post_dz, 95):.1f}"
+                           f" (rematch z+/-{_rematch_search_z})[/dim]")
 
         iou_final = cascade_state['iou']
         rprint(f"  [bold]Final: IoU {iou_baseline:.3f}→{iou_final:.3f} ({iou_final - iou_baseline:+.3f})[/bold]")
@@ -1224,8 +1270,9 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
             (y1, x1), max_dist=QUAD_BLEND_DIST)
         z_map_local = z_map_base_full + g_dz + cumulative_dz
 
-        # Compute final IoU in full space for QA
-        hcr_final_full = sample_hcr_binary_at_zmap(hcr_ref_masks > 0, z_map_local)
+        # Sample HCR at the exact interpolated z-plane (no ±1 MIP) for the QA overlay.
+        # IoU is taken from cascade_state['iou'] above, not recomputed here.
+        hcr_final_full = sample_hcr_binary_at_zmap(hcr_ref_masks > 0, z_map_local, z_expand=0)
         twop_final_binary = twop_final_labels > 0
         fov_final = create_fov_mask_convex_hull(twop_final_binary, margin=30)
         hcr_local = hcr_final_full  # for QA overlay
@@ -1260,7 +1307,7 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
         qa_folder = output_root(full_manifest) / '2P' / 'registered' / 'QualityCheck'
         qa_folder.mkdir(parents=True, exist_ok=True)
 
-        hcr_baseline_full = sample_hcr_binary_at_zmap(hcr_ref_masks > 0, z_map_base_full)
+        hcr_baseline_full = sample_hcr_binary_at_zmap(hcr_ref_masks > 0, z_map_base_full, z_expand=0)
         twop_binary_full = (twop_warped > 0).astype(np.uint16)
         overlay_before = np.stack([hcr_baseline_full.astype(np.uint16), twop_binary_full], axis=0)
         qa_before_path = qa_folder / f'plane{plane}_BEFORE_registration_overlay.tiff'
@@ -1331,6 +1378,11 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
             # Metadata
             erosion=EROSION,
             erosion_hcr=EROSION_HCR,
+            use_nn_fallback=np.array(USE_NN_FALLBACK),
+            data_sigma_mult=DATA_SIGMA_MULT,
+            border_decay_mult=BORDER_DECAY_MULT,
+            border_weight_floor=BORDER_WEIGHT_FLOOR,
+            disable_border_anchors=np.array(DISABLE_BORDER_ANCHORS),
             hcr_shape=np.array(hcr_ref_masks.shape),
             # v9: erode_labels with cell-cell boundaries, wider coarse search
             algorithm_version=np.array(10),
@@ -1341,6 +1393,52 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
         )
         with open(str(params_path), 'wb') as f:
             f.write(buf.getvalue())
+
+        # ---- SAVE PER-STAGE 2-CHANNEL LABEL TIFFs (CYX uint16) ----
+        # For each alignment stage already captured in `cascade_snapshots`
+        # (baseline = TPS-only, global = TPS+rigid, affine, tile_300, tile_100,
+        # tile_50), write a 2-channel TIFF padded to the full HCR (Y, X) field:
+        #   ch0 = HCR labels nearest-neighbor-sampled at THAT stage's z_map
+        #   ch1 = 2P labels at that stage's transform
+        # Padded so all stages share one frame and co-register with z_map_local
+        # in {twop_plane{N}_registration_params.npz}. Figure notebooks (e.g.
+        # panel_gene_mask_strip_*.ipynb) consume these directly instead of the
+        # v18 aligned-masks NPZ.
+        _inner_origin_full = (bb_y0 + cy0, bb_x0 + cx0)
+        _outer_origin_full = (bb_y0, bb_x0)
+        for _stage_name, _snap in cascade_snapshots.items():
+            _frame = _snap['frame']
+            _oy, _ox = (_outer_origin_full if _frame == 'outer_crop'
+                        else _inner_origin_full)
+            _tp_stage = _snap['twop_labels']            # uint16, stage crop frame
+            _zm_stage = _snap['z_map']                  # float32, stage crop frame
+            _sh = _tp_stage.shape
+
+            _hcr_3d_in = hcr_ref_masks[:, _oy:_oy + _sh[0], _ox:_ox + _sh[1]]
+            _zz = np.clip(np.round(_zm_stage).astype(int),
+                          0, _hcr_3d_in.shape[0] - 1)
+            _yi, _xi = np.mgrid[0:_sh[0], 0:_sh[1]]
+            _hp_stage = _hcr_3d_in[_zz, _yi, _xi].astype(np.uint16)
+
+            _tp_full = np.zeros((y1, x1), dtype=np.uint16)
+            _hp_full = np.zeros((y1, x1), dtype=np.uint16)
+            _tp_full[_oy:_oy + _sh[0], _ox:_ox + _sh[1]] = _tp_stage
+            _hp_full[_oy:_oy + _sh[0], _ox:_ox + _sh[1]] = _hp_stage
+
+            _stack = np.stack([_hp_full, _tp_full], axis=0)
+            _stage_path = qa_folder / f'plane{plane}_stage_{_stage_name}.tiff'
+            _meta = {
+                'axes': 'CYX',
+                'Labels': ['HCR_labels_at_zmap', '2P_labels'],
+                'Description': (
+                    f'plane={plane} stage={_stage_name} '
+                    f'iou={_snap["iou"]:.4f} frame={_frame} '
+                    f'crop_origin_yx=({_oy},{_ox})'
+                ),
+            }
+            tif_imwrite(str(_stage_path), _stack, imagej=True, metadata=_meta)
+        rprint(f"[dim]  Saved {len(cascade_snapshots)} per-stage label TIFFs "
+               f"in QualityCheck/[/dim]")
 
     # --- SAVE PER-PLANE AUTO LANDMARKS ---
     orig_landmarks = pd.read_csv(landmarks_path, header=None)

--- a/src/registrations.py
+++ b/src/registrations.py
@@ -57,6 +57,8 @@ sys.path = ["/mnt/nasquatch/data/2p/jonna/Code_Python/Notebooks_Jonna/BigStream/
 
 from bigstream.piecewise_transform import distributed_apply_transform
 
+from .meta import output_root
+
 
 def _resolve_hcr_path(expected_path: Path) -> Path:
     """Resolve an HCR TIFF path with case-insensitive and extension-flexible matching.
@@ -136,8 +138,8 @@ def registration_apply(full_manifest):
 
         round_folder_name = f"HCR{HCR_round_to_register}_to_HCR{reference_round['round']}"
 
-        reg_path =  Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'HCR' / 'registrations'/ round_folder_name / round_to_rounds[HCR_round_to_register]['registrations'][0]
-        full_stack_path =  Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'HCR' / 'full_registered_stacks' / f"{round_folder_name}.tiff"
+        reg_path =  output_root(full_manifest) / 'HCR' / 'registrations'/ round_folder_name / round_to_rounds[HCR_round_to_register]['registrations'][0]
+        full_stack_path =  output_root(full_manifest) / 'HCR' / 'full_registered_stacks' / f"{round_folder_name}.tiff"
         if full_stack_path.exists():
             continue
         full_stack_path.parent.mkdir(exist_ok=True, parents=True)
@@ -218,7 +220,7 @@ def registration_apply(full_manifest):
         tif_imwrite(full_stack_path, full_stack.transpose(3, 0, 2, 1), imagej=True, metadata={'axes': 'ZCYX'})
 
     # Now let's also copy the reference_round to the full_registered_stacks folder
-    reference_round_full_stack_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'HCR' / 'full_registered_stacks' / f"HCR{reference_round['round']}.tiff"
+    reference_round_full_stack_path = output_root(full_manifest) / 'HCR' / 'full_registered_stacks' / f"HCR{reference_round['round']}.tiff"
     if not reference_round_full_stack_path.exists():
         shutil.copyfile(HCR_fix_image_path, reference_round_full_stack_path)
             
@@ -255,7 +257,7 @@ def verify_rounds(full_manifest, parse_registered = False, print_rounds = False,
         txt_to_rich = f"[green]Rounds available for {func} [/green]:"
         for i in selected_registrations['HCR_selected_registrations']['rounds']:
             assert i['round'] in round_to_rounds, f"Round {i['round']} not defined in manifest!"
-            selected_registration_path =  Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'HCR' / 'registrations'/ f"HCR{i['round']}_to_HCR{reference_round_number}" / i['selected_registrations'][0]
+            selected_registration_path =  output_root(full_manifest) / 'HCR' / 'registrations'/ f"HCR{i['round']}_to_HCR{reference_round_number}" / i['selected_registrations'][0]
             assert os.path.exists(selected_registration_path), f"Registration {selected_registration_path} not found although it exists in the manifest params"
 
             round_to_rounds[i['round']]['registrations'] = i['selected_registrations']
@@ -276,7 +278,7 @@ def register_rounds(full_manifest):
     # If only one round (reference), nothing to register — just copy reference and return
     if len(round_to_rounds) == 0:
         rprint("\n[bold cyan]Only one HCR round — skipping round-to-round registration[/bold cyan]")
-        reference_round_full_stack_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'HCR' / 'full_registered_stacks' / f"HCR{reference_round['round']}.tiff"
+        reference_round_full_stack_path = output_root(full_manifest) / 'HCR' / 'full_registered_stacks' / f"HCR{reference_round['round']}.tiff"
         reference_round_full_stack_path.parent.mkdir(parents=True, exist_ok=True)
         if not reference_round_full_stack_path.exists():
             shutil.copyfile(reference_round['image_path'], reference_round_full_stack_path)
@@ -291,7 +293,7 @@ def register_rounds(full_manifest):
     rprint("Registration process uses step-by-step jupyter notebooks\n")
 
     # Ensure reference round is copied in case user has only Rounds = 1
-    reference_round_full_stack_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'HCR' / 'full_registered_stacks' / f"HCR{reference_round['round']}.tiff"
+    reference_round_full_stack_path = output_root(full_manifest) / 'HCR' / 'full_registered_stacks' / f"HCR{reference_round['round']}.tiff"
     if not reference_round_full_stack_path.exists():
         reference_round_full_stack_path.parent.mkdir(parents=True, exist_ok=True)
         rprint(f"[yellow]Copying reference round {reference_round['round']} to full_registered_stacks[/yellow]")
@@ -368,7 +370,7 @@ def create_rotated_masks_for_standard_mode(full_manifest, session):
 
     for plane_idx in all_planes:
         plane_idx = int(plane_idx)
-        masks_path = base_path / mouse / 'OUTPUT' / '2P' / 'cellpose' / f'lowres_meanImg_C0_plane{plane_idx}_seg.npy'
+        masks_path = output_root(full_manifest) / '2P' / 'cellpose' / f'lowres_meanImg_C0_plane{plane_idx}_seg.npy'
         if not masks_path.exists():
             rprint(f"  [yellow]Plane {plane_idx}: masks not found, skipping[/yellow]")
             continue
@@ -382,7 +384,7 @@ def create_rotated_masks_for_standard_mode(full_manifest, session):
         if flip_ud:
             masks = np.flipud(masks)
 
-        output_path = base_path / mouse / 'OUTPUT' / '2P' / 'cellpose' / f'lowres_meanImg_C0_plane{plane_idx}_seg_rotated.tiff'
+        output_path = output_root(full_manifest) / '2P' / 'cellpose' / f'lowres_meanImg_C0_plane{plane_idx}_seg_rotated.tiff'
         tif_imwrite(str(output_path), masks.astype(np.uint16))
         rprint(f"  Plane {plane_idx}: saved rotated masks")
 
@@ -435,7 +437,7 @@ def register_lowres_to_hires(full_manifest, session):
         TARGET_PLANES = [REFERENCE_PLANE] + ADDITIONAL_PLANES
 
     # Output directories
-    output_dir = base_path / mouse / 'OUTPUT' / '2P' / 'registered'
+    output_dir = output_root(full_manifest) / '2P' / 'registered'
     qa_dir = output_dir / 'QualityCheck' / 'lowres_to_hires'
     qa_dir.mkdir(parents=True, exist_ok=True)
 
@@ -453,13 +455,13 @@ def register_lowres_to_hires(full_manifest, session):
 
         # --- LOAD IMAGES ---
         # Low-res: rotated mean image from Suite2p
-        lowres_img_path = base_path / mouse / 'OUTPUT' / '2P' / 'registered' / f'lowres_meanImg_C0_plane{plane_idx}_rotated.tiff'
+        lowres_img_path = output_root(full_manifest) / '2P' / 'registered' / f'lowres_meanImg_C0_plane{plane_idx}_rotated.tiff'
 
         # High-res: rotated stitched image (use mean projection of channel 0)
-        hires_img_path = base_path / mouse / 'OUTPUT' / '2P' / 'registered' / f'hires_stitched_plane{plane_idx}_rotated.tiff'
+        hires_img_path = output_root(full_manifest) / '2P' / 'registered' / f'hires_stitched_plane{plane_idx}_rotated.tiff'
 
         # Low-res masks: cellpose output (before rotation)
-        lowres_masks_path = base_path / mouse / 'OUTPUT' / '2P' / 'cellpose' / f'lowres_meanImg_C0_plane{plane_idx}_seg.npy'
+        lowres_masks_path = output_root(full_manifest) / '2P' / 'cellpose' / f'lowres_meanImg_C0_plane{plane_idx}_seg.npy'
 
         # Check files exist
         missing = []
@@ -493,7 +495,7 @@ def register_lowres_to_hires(full_manifest, session):
             lowres_masks = np.flipud(lowres_masks)
 
         # Save rotated masks as TIFF (same location as landmark path uses)
-        rotated_masks_path = base_path / mouse / 'OUTPUT' / '2P' / 'cellpose' / f'lowres_meanImg_C0_plane{plane_idx}_seg_rotated.tiff'
+        rotated_masks_path = output_root(full_manifest) / '2P' / 'cellpose' / f'lowres_meanImg_C0_plane{plane_idx}_seg_rotated.tiff'
         tif_imwrite(str(rotated_masks_path), lowres_masks.astype(np.uint16))
 
         # Extract 2D from high-res (could be ZCYX or CYX)
@@ -713,7 +715,7 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
     TARGET_PLANES = [CURRENT_PLANE]  # Process only the current plane per call
 
     # Check existing outputs and prompt user for each plane
-    output_dir = base_path / mouse / 'OUTPUT' / '2P' / 'registered'
+    output_dir = output_root(full_manifest) / '2P' / 'registered'
     overwrite_state = [None]
     planes_to_process = []
 
@@ -734,22 +736,22 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
                                                                     print_rounds = False, print_registered = False)
 
     # HCR paths
-    hcr_ref_round_path = base_path / mouse / 'OUTPUT' / 'HCR' / 'full_registered_stacks' / f"HCR{reference_round['round']}.tiff"
-    hcr_ref_masks_path = base_path / mouse / 'OUTPUT' / 'HCR' / 'cellpose' / f"HCR{reference_round['round']}_masks.tiff"
+    hcr_ref_round_path = output_root(full_manifest) / 'HCR' / 'full_registered_stacks' / f"HCR{reference_round['round']}.tiff"
+    hcr_ref_masks_path = output_root(full_manifest) / 'HCR' / 'cellpose' / f"HCR{reference_round['round']}_masks.tiff"
 
     # WORKFLOW DETECTION: Choose reference image and landmarks based on has_hires
-    landmarks_dir = base_path / mouse / 'OUTPUT' / '2P' / 'registered'
+    landmarks_dir = output_root(full_manifest) / '2P' / 'registered'
     # Reference round number for file naming (strip leading zeros: "01" -> "1")
     hcr_ref = str(int(reference_round['round']))
 
     if has_hires:
-        twop_ref_image_path = base_path / mouse / 'OUTPUT' / '2P' / 'registered' / f'hires_stitched_plane{REFERENCE_PLANE}_rotated.tiff'
+        twop_ref_image_path = output_root(full_manifest) / '2P' / 'registered' / f'hires_stitched_plane{REFERENCE_PLANE}_rotated.tiff'
         landmarks_path, landmarks_source = auto.find_landmark_file(
             landmarks_dir, REFERENCE_PLANE, prefix="hires_stitched_", hcr_ref=hcr_ref
         )
         rprint(f"[dim]Mode: high-res stitched[/dim]")
     else:
-        twop_ref_image_path = base_path / mouse / 'OUTPUT' / '2P' / 'cellpose' / f'lowres_meanImg_C0_plane{REFERENCE_PLANE}_seg_rotated.tiff'
+        twop_ref_image_path = output_root(full_manifest) / '2P' / 'cellpose' / f'lowres_meanImg_C0_plane{REFERENCE_PLANE}_seg_rotated.tiff'
         landmarks_path, landmarks_source = auto.find_landmark_file(
             landmarks_dir, REFERENCE_PLANE, prefix="", hcr_ref=hcr_ref
         )
@@ -767,7 +769,7 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
         # Build clear instructions telling user which files to open in BigWarp
         if has_hires:
             twop_file = f"hires_stitched_plane{REFERENCE_PLANE}_rotated.tiff"
-            twop_file_path = base_path / mouse / 'OUTPUT' / '2P' / 'registered' / twop_file
+            twop_file_path = output_root(full_manifest) / '2P' / 'registered' / twop_file
             instructions = (
                 f"In BigWarp, open these two images:\n"
                 f"  Moving: {twop_file_path}\n"
@@ -776,7 +778,7 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
             )
         else:
             twop_file = f"lowres_meanImg_C0_plane{REFERENCE_PLANE}_seg_rotated.tiff"
-            twop_file_path = base_path / mouse / 'OUTPUT' / '2P' / 'cellpose' / twop_file
+            twop_file_path = output_root(full_manifest) / '2P' / 'cellpose' / twop_file
             instructions = (
                 f"In BigWarp, open these two images:\n"
                 f"  Moving: {twop_file_path}\n"
@@ -798,7 +800,7 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
     rprint(f"[dim]Using {landmarks_source} landmarks: {landmarks_path.name}[/dim]")
 
     # Create output folders
-    output_folder = base_path / mouse / 'OUTPUT' / 'MERGED' / 'aligned_masks'
+    output_folder = output_root(full_manifest) / 'MERGED' / 'aligned_masks'
     output_folder.mkdir(parents=True, exist_ok=True)
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -830,14 +832,14 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
     twop_2d_planes = {}
     for plane in TARGET_PLANES:
         if has_hires:
-            twop_path = base_path / mouse / 'OUTPUT' / '2P' / 'registered' / f'lowres_plane{plane}_masks_in_hires_space.tiff'
+            twop_path = output_root(full_manifest) / '2P' / 'registered' / f'lowres_plane{plane}_masks_in_hires_space.tiff'
             if not twop_path.exists():
                 raise FileNotFoundError(
                     f"High-res transformed masks not found: {twop_path}\n"
                     f"Please ensure register_lowres_to_hires() has completed successfully."
                 )
         else:
-            twop_path = base_path / mouse / 'OUTPUT' / '2P' / 'cellpose' / f'lowres_meanImg_C0_plane{plane}_seg_rotated.tiff'
+            twop_path = output_root(full_manifest) / '2P' / 'cellpose' / f'lowres_meanImg_C0_plane{plane}_seg_rotated.tiff'
         twop_2d_planes[plane] = tif_imread(str(twop_path))
         rprint(f"[dim]  2P masks plane {plane}: shape={twop_2d_planes[plane].shape} (from {twop_path.name})[/dim]")
 
@@ -1199,11 +1201,11 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
         twop_3d[z_coords, yy, xx] = twop_final_labels
 
         # Save the final aligned 3D volume
-        output_path = base_path / mouse / 'OUTPUT' / '2P' / 'registered' / f'twop_plane{plane}_aligned_3d.tiff'
+        output_path = output_root(full_manifest) / '2P' / 'registered' / f'twop_plane{plane}_aligned_3d.tiff'
         tif_imwrite(str(output_path), twop_3d.astype(np.uint16))
 
         # Save QualityCheck overlay TIFFs
-        qa_folder = base_path / mouse / 'OUTPUT' / '2P' / 'registered' / 'QualityCheck'
+        qa_folder = output_root(full_manifest) / '2P' / 'registered' / 'QualityCheck'
         qa_folder.mkdir(parents=True, exist_ok=True)
 
         hcr_baseline_full = sample_hcr_binary_at_zmap(hcr_ref_masks > 0, z_map_base_full)
@@ -1253,7 +1255,7 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
                     overlay_after_es, imagej=True, metadata={'axes': 'CYX'})
 
         # --- SAVE REGISTRATION PARAMS ---
-        params_path = base_path / mouse / 'OUTPUT' / '2P' / 'registered' / f'twop_plane{plane}_registration_params.npz'
+        params_path = output_root(full_manifest) / '2P' / 'registered' / f'twop_plane{plane}_registration_params.npz'
         params_path.parent.mkdir(parents=True, exist_ok=True)
         import io as _io
         buf = _io.BytesIO()

--- a/src/registrations.py
+++ b/src/registrations.py
@@ -1021,6 +1021,27 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
             'dz_cum':      np.zeros((ny_c, nx_c)),
         }
 
+        # ---- CASCADE SNAPSHOTS (for cp4-eval and future regression checks) ----
+        # Captures the alignment state at each named stage so a comparison
+        # notebook can plot IoU progression and spatial IoU heatmaps without
+        # re-running the cascade. baseline/global live in the outer (landmark
+        # bbox) crop; affine and the cascade-tile stages live in the inner
+        # (FOV) crop. frame_meta below records the origins.
+        cascade_snapshots = {
+            'baseline': {'iou': float(iou_baseline),
+                         'twop_labels': twop_labels_crop.astype(np.uint16, copy=True),
+                         'z_map': z_map_baseline.astype(np.float32, copy=True),
+                         'frame': 'outer_crop'},
+            'global':   {'iou': float(iou_global),
+                         'twop_labels': twop_global_labels.astype(np.uint16, copy=True),
+                         'z_map': z_map_global.astype(np.float32, copy=True),
+                         'frame': 'outer_crop'},
+            'affine':   {'iou': float(iou_affine),
+                         'twop_labels': twop_affine_labels.astype(np.uint16, copy=True),
+                         'z_map': z_map_affine.astype(np.float32, copy=True),
+                         'frame': 'inner_crop'},
+        }
+
         df_post_rematch = None  # will be set after first cascade stage
         for _si, tile_size in enumerate(CASCADE_STAGES):
             td = TILE_DEFAULTS[tile_size]
@@ -1115,6 +1136,17 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
             cascade_state['dx_cum'] += dx_inc
             cascade_state['dz_cum'] += dz_inc
 
+            # Snapshot at end of this cascade stage (always recorded, including
+            # the reverted no-op case so cp3↔cp4 comparison can see at which
+            # stages each version stalled or regressed).
+            cascade_snapshots[f'tile_{tile_size}'] = {
+                'iou':         float(cascade_state['iou']),
+                'twop_labels': cascade_state['twop_labels'].astype(np.uint16, copy=True),
+                'z_map':       cascade_state['z_map'].astype(np.float32, copy=True),
+                'frame':       'inner_crop',
+                'tile_size':   int(tile_size),
+            }
+
             # Post-correction re-match: measure actual remaining residuals
             # This feeds accurate adaptive params to the next cascade stage.
             if _si < len(CASCADE_STAGES) - 1:  # no need after last stage
@@ -1135,6 +1167,26 @@ def twop_to_hcr_registration(full_manifest, session, has_hires=False, automation
 
         iou_final = cascade_state['iou']
         rprint(f"  [bold]Final: IoU {iou_baseline:.3f}→{iou_final:.3f} ({iou_final - iou_baseline:+.3f})[/bold]")
+
+        # ---- SAVE CASCADE SNAPSHOTS ----
+        # Pickled per-stage state for offline analysis (cp3↔cp4 comparison,
+        # regression checks, parameter tuning). Adds ~50-150 MB per plane.
+        import pickle as _pkl
+        snapshots_path = output_root(full_manifest) / '2P' / 'registered' / f'cascade_snapshots_plane{plane}.pkl'
+        snapshots_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(snapshots_path, 'wb') as _f:
+            _pkl.dump({
+                'snapshots': cascade_snapshots,
+                'stages_order': list(cascade_snapshots.keys()),
+                'frame_meta': {
+                    'outer_crop_origin': (int(bb_y0), int(bb_x0)),
+                    'outer_crop_shape': (int(bb_y1 - bb_y0), int(bb_x1 - bb_x0)),
+                    'inner_crop_origin_within_outer': (int(cy0), int(cx0)),
+                    'inner_crop_shape': (int(cy1 - cy0), int(cx1 - cx0)),
+                    'full_hcr_shape': (int(y1), int(x1)),
+                },
+            }, _f)
+        rprint(f"  [dim]Cascade snapshots → {snapshots_path.name}[/dim]")
 
         # ---- UNCROP: Compose displacement fields back to full HCR space ----
         # Total displacement in inner-crop space

--- a/src/registrations_landmarks.py
+++ b/src/registrations_landmarks.py
@@ -13,6 +13,8 @@ from skimage.transform import PiecewiseAffineTransform, warp
 from scipy.interpolate import Rbf
 from tifffile import imread as tif_imread, imwrite as tif_imwrite
 
+from .meta import output_root
+
 try:
     from . import automation as auto
     from .meta import get_rotation_config
@@ -114,7 +116,7 @@ def register_lowres_to_hires_landmarks(full_manifest, session):
     print(f"Planes: {TARGET_PLANES} (ref: {REFERENCE_PLANE})")
 
     # Output directories
-    output_dir = base_path / mouse / 'OUTPUT' / '2P' / 'registered'
+    output_dir = output_root(full_manifest) / '2P' / 'registered'
     qa_dir = output_dir / 'QualityCheck' / 'lowres_to_hires'
 
     # Create QualityCheck directory - handle case where 'QualityCheck' exists as a file
@@ -139,13 +141,13 @@ def register_lowres_to_hires_landmarks(full_manifest, session):
 
         # --- LOAD FILES ---
         # Low-res: rotated mean image from Suite2p
-        lowres_img_path = base_path / mouse / 'OUTPUT' / '2P' / 'registered' / f'lowres_meanImg_C0_plane{plane_idx}_rotated.tiff'
+        lowres_img_path = output_root(full_manifest) / '2P' / 'registered' / f'lowres_meanImg_C0_plane{plane_idx}_rotated.tiff'
 
         # High-res: rotated stitched image
-        hires_img_path = base_path / mouse / 'OUTPUT' / '2P' / 'registered' / f'hires_stitched_plane{plane_idx}_rotated.tiff'
+        hires_img_path = output_root(full_manifest) / '2P' / 'registered' / f'hires_stitched_plane{plane_idx}_rotated.tiff'
 
         # Low-res masks: cellpose output (will rotate on-the-fly)
-        lowres_masks_path = base_path / mouse / 'OUTPUT' / '2P' / 'cellpose' / f'lowres_meanImg_C0_plane{plane_idx}_seg.npy'
+        lowres_masks_path = output_root(full_manifest) / '2P' / 'cellpose' / f'lowres_meanImg_C0_plane{plane_idx}_seg.npy'
 
         # User-provided landmarks (only for reference plane)
         landmarks_path = output_dir / f'lowres_to_hires_plane{REFERENCE_PLANE}_landmarks.csv'
@@ -213,7 +215,7 @@ def register_lowres_to_hires_landmarks(full_manifest, session):
             lowres_masks = np.flipud(lowres_masks)
 
         # Save rotated masks as TIFF for use by rest of pipeline
-        rotated_masks_path = base_path / mouse / 'OUTPUT' / '2P' / 'cellpose' / f'lowres_meanImg_C0_plane{plane_idx}_seg_rotated.tiff'
+        rotated_masks_path = output_root(full_manifest) / '2P' / 'cellpose' / f'lowres_meanImg_C0_plane{plane_idx}_seg_rotated.tiff'
         tif_imwrite(str(rotated_masks_path), lowres_masks.astype(np.uint16))
 
         # Extract 2D from high-res (could be ZCYX or CYX)

--- a/src/registrations_landmarks.py
+++ b/src/registrations_landmarks.py
@@ -8,12 +8,14 @@ to handle non-linear distortions between low-res and high-res images.
 import numpy as np
 import pandas as pd
 from pathlib import Path
-from rich import print as rprint
 from skimage.transform import PiecewiseAffineTransform, warp
 from scipy.interpolate import Rbf
 from tifffile import imread as tif_imread, imwrite as tif_imwrite
 
-from .meta import output_root
+try:
+    from .meta import output_root, rprint  # Relative import (running as part of a package)
+except ImportError:
+    from meta import output_root, rprint  # Absolute import (running in Jupyter notebook)
 
 try:
     from . import automation as auto

--- a/src/registrations_utils.py
+++ b/src/registrations_utils.py
@@ -425,6 +425,65 @@ def apply_shift_fields(mask_2d, dy_field, dx_field, order=0, return_labels=False
         # Return binary (for IoU calculation)
         return shifted > 0.5
 
+def read_tiff_resolution(tiff_path):
+    """Return [x, y, z] um/px from ImageJ TIFF metadata, or None if unreadable.
+
+    Expects XResolution/YResolution as pixels-per-micron and ImageJ `spacing` for Z,
+    with `unit=micron`. Any missing piece yields None.
+    """
+    try:
+        with TiffFile(str(tiff_path)) as t:
+            ij = t.imagej_metadata or {}
+            if str(ij.get('unit', '')).lower() not in ('micron', 'microns', 'um', 'µm'):
+                return None
+            xr = t.pages[0].tags.get('XResolution')
+            yr = t.pages[0].tags.get('YResolution')
+            z_um = ij.get('spacing')
+            if xr is None or yr is None or not z_um or z_um <= 0:
+                return None
+            (xn, xd), (yn, yd) = xr.value, yr.value
+            if not xd or not yd or xn <= 0 or yn <= 0:
+                return None
+            return [float(xd / xn), float(yd / yn), float(z_um)]
+    except Exception:
+        return None
+
+
+def resolve_hcr_resolution(tiff_path, manifest_resolution=None, tolerance=0.01):
+    """Pick final HCR resolution. TIFF metadata is the default; manifest overrides.
+
+    Warns loudly when an override disagrees with metadata by more than `tolerance`.
+    Raises ValueError if neither source is available.
+    """
+    tiff_res = read_tiff_resolution(tiff_path)
+    name = Path(tiff_path).name
+
+    if tiff_res is None and manifest_resolution is None:
+        raise ValueError(
+            f"HCR resolution unavailable: no readable TIFF metadata at {tiff_path} "
+            f"and no `resolution` set in manifest's rounds entry.")
+
+    if tiff_res is None:
+        print(f"  [WARN] HCR resolution: TIFF metadata unreadable at {name}; "
+              f"using manifest {manifest_resolution} unverified.")
+        return list(manifest_resolution)
+
+    if manifest_resolution is None:
+        print(f"  HCR resolution from {name}: "
+              f"[{tiff_res[0]:.4f}, {tiff_res[1]:.4f}, {tiff_res[2]:.4f}] um/px")
+        return tiff_res
+
+    max_frac = max(abs((m - t) / t) for m, t in zip(manifest_resolution, tiff_res))
+    if max_frac > tolerance:
+        print(f"  [WARN] HCR resolution: manifest {list(manifest_resolution)} "
+              f"disagrees with {name} {[round(v, 4) for v in tiff_res]} "
+              f"by {max_frac*100:.1f}%. Using manifest as override "
+              f"(remove field to trust metadata).")
+    else:
+        print(f"  HCR resolution: manifest matches {name} ({list(manifest_resolution)} um/px).")
+    return list(manifest_resolution)
+
+
 def add_px_columns(landmarks_df, hcr_resolution):
     """
     Convert landmark coordinates to pixel units.
@@ -1010,6 +1069,7 @@ def refine_lowres_to_hires_with_tiles(lowres_aligned, hires_2d, masks, config=No
     tile_overlap = config.get('tile_overlap', 0.3)
     blend_width = config.get('blend_width', 40)
     max_shift = config.get('max_shift', 40)
+    scale_tol = config.get('scale_tol', 0.20)  # accepted local scale window: [1-scale_tol, 1+scale_tol]
     min_overlap_fraction = config.get('min_overlap_fraction', 0.5)
     require_ncc_improvement = config.get('require_ncc_improvement', True)
 
@@ -1021,7 +1081,6 @@ def refine_lowres_to_hires_with_tiles(lowres_aligned, hires_2d, masks, config=No
     ratio_threshold = config.get('ratio_threshold', 0.7)
     ransac_reproj_threshold = config.get('ransac_reproj_threshold', 3.0)
     percentile_norm = config.get('percentile_norm', (2, 98))  # Percentile-based normalization
-    verbose = config.get('verbose', False)
 
     h, w = hires_2d.shape
     step = max(1, int(tile_size * (1 - tile_overlap)))
@@ -1051,13 +1110,12 @@ def refine_lowres_to_hires_with_tiles(lowres_aligned, hires_2d, masks, config=No
         'percentile_norm': percentile_norm,
     }
 
-    # Accumulators for direct tile application with weighted blending
-    warped_img_sum = np.zeros((h, w), dtype=np.float64)
-    weight_sum = np.zeros((h, w), dtype=np.float64)
-    # For masks: use winner-takes-all (highest weight wins) instead of weighted average
-    # Weighted averaging corrupts label IDs (e.g., averaging label 5 and 10 gives 7.5 -> wrong cell!)
-    masks_result = masks.copy()  # Start with original masks
-    masks_max_weight = np.zeros((h, w), dtype=np.float64)  # Track highest weight per pixel
+    # Accumulate per-pixel DISPLACEMENTS (not warped pixels). Averaging warped
+    # pixels superposes copies when adjacent tiles' affines disagree; averaging
+    # displacements and remapping once is coherent. Masks ride the same field.
+    dy_field_sum = np.zeros((h, w), dtype=np.float64)
+    dx_field_sum = np.zeros((h, w), dtype=np.float64)
+    weight_sum   = np.zeros((h, w), dtype=np.float64)
 
     tile_results = []
     # Track failure reasons for diagnostics
@@ -1126,8 +1184,9 @@ def refine_lowres_to_hires_with_tiles(lowres_aligned, hires_2d, masks, config=No
             scale_y = np.sqrt(b**2 + d**2)
             dx, dy = affine_matrix[0, 2], affine_matrix[1, 2]
 
-            # Reject if scale deviates more than 20% from identity or shift exceeds max
-            scale_ok = (0.80 <= scale_x <= 1.20) and (0.80 <= scale_y <= 1.20)
+            # Reject if scale deviates more than scale_tol from identity or shift exceeds max_shift
+            scale_lo, scale_hi = 1.0 - scale_tol, 1.0 + scale_tol
+            scale_ok = (scale_lo <= scale_x <= scale_hi) and (scale_lo <= scale_y <= scale_hi)
             shift_ok = (abs(dx) <= max_shift) and (abs(dy) <= max_shift)
 
             if not scale_ok:
@@ -1140,7 +1199,9 @@ def refine_lowres_to_hires_with_tiles(lowres_aligned, hires_2d, masks, config=No
                 failure_reasons['bad_shift'] += 1
                 continue
 
-            # Apply affine correction to get warped tile
+            # Warp the tile once for NCC quality gating only — not used downstream.
+            # (The actual refinement applies a single coherent remap built from the
+            # blended displacement field below; this warp is just for validation.)
             warped_lowres_tile = cv2.warpAffine(
                 lowres_tile, affine_matrix, (tile_w, tile_h),
                 flags=cv2.INTER_LINEAR, borderMode=cv2.BORDER_REPLICATE
@@ -1153,11 +1214,16 @@ def refine_lowres_to_hires_with_tiles(lowres_aligned, hires_2d, masks, config=No
                 failure_reasons['ncc_worse'] += 1
                 continue
 
-            # Apply same affine to masks (nearest-neighbor for labels)
-            warped_masks_tile = cv2.warpAffine(
-                masks_tile, affine_matrix, (tile_w, tile_h),
-                flags=cv2.INTER_NEAREST, borderMode=cv2.BORDER_REPLICATE
-            )
+            # Build the per-tile displacement field from the INVERSE of the affine.
+            # cv2.estimateAffine2D returns the FORWARD matrix (src→dst); cv2.warpAffine
+            # auto-inverts it internally. cv2.remap does NOT auto-invert, so we must
+            # invert here so dx_field = output - src goes the correct direction.
+            M_inv = cv2.invertAffineTransform(affine_matrix)
+            yy_tile, xx_tile = np.mgrid[0:tile_h, 0:tile_w].astype(np.float64)
+            a_, b_, tx_ = M_inv[0]
+            c_, d_, ty_ = M_inv[1]
+            dx_tile = (a_ * xx_tile + b_ * yy_tile + tx_) - xx_tile
+            dy_tile = (c_ * xx_tile + d_ * yy_tile + ty_) - yy_tile
 
             # Create feathered weight mask (1 in center, tapered to 0 at edges)
             weight = np.ones((tile_h, tile_w), dtype=np.float64)
@@ -1170,15 +1236,10 @@ def refine_lowres_to_hires_with_tiles(lowres_aligned, hires_2d, masks, config=No
                 weight[:, j] *= factor
                 weight[:, tile_w - 1 - j] *= factor
 
-            # Accumulate weighted contributions for image (blending is fine for images)
-            warped_img_sum[y0:y1, x0:x1] += warped_lowres_tile * weight
-            weight_sum[y0:y1, x0:x1] += weight
-
-            # For masks: winner-takes-all (update only where this tile has higher weight)
-            # This preserves label IDs instead of corrupting them via averaging
-            update_mask = weight > masks_max_weight[y0:y1, x0:x1]
-            masks_result[y0:y1, x0:x1] = np.where(update_mask, warped_masks_tile, masks_result[y0:y1, x0:x1])
-            masks_max_weight[y0:y1, x0:x1] = np.maximum(masks_max_weight[y0:y1, x0:x1], weight)
+            # Accumulate weighted DISPLACEMENT contributions (not warped pixels).
+            dy_field_sum[y0:y1, x0:x1] += dy_tile * weight
+            dx_field_sum[y0:y1, x0:x1] += dx_tile * weight
+            weight_sum  [y0:y1, x0:x1] += weight
 
             tile_results.append({'cy': cy, 'success': True, 'ncc_before': ncc_before, 'ncc_after': ncc_after, 'shift': (dx, dy)})
 
@@ -1186,27 +1247,37 @@ def refine_lowres_to_hires_with_tiles(lowres_aligned, hires_2d, masks, config=No
             tile_results.append({'cy': cy, 'success': False, 'reason': 'exception', 'error': str(e)})
             failure_reasons['exception'] += 1
 
-    # Print failure summary
-    if verbose:
-        print(f"  Tile failure breakdown: {failure_reasons}")
-
-    # If no successful tiles, return original
+    # Always-on failure summary + accepted-tile shift stats.
+    n_total   = len(tile_positions)
     n_success = sum(1 for t in tile_results if t.get('success'))
+    if n_total - n_success > 0:
+        parts = [f"{r}={n}" for r, n in failure_reasons.items() if n > 0]
+        print(f"  Tile refinement: {n_success}/{n_total} accepted — failed: {', '.join(parts)}")
+    if n_success > 0:
+        mags = np.linalg.norm([t['shift'] for t in tile_results if t.get('success')], axis=1)
+        p95 = float(np.percentile(mags, 95))
+        warn = "  — P95 near cap, consider raising max_shift" if p95 > 0.9 * max_shift else ""
+        print(f"  Accepted-tile shift |dxy|: median={np.median(mags):.2f}px, P95={p95:.2f}px (cap={max_shift}){warn}")
+
     if n_success < 1:
         return masks.copy(), lowres_aligned.copy(), tile_results
 
-    # Compute final result: divide by total weight for image, use winner-takes-all for masks
-    no_coverage_mask = weight_sum < 0.01
-    weight_sum_safe = np.maximum(weight_sum, 1e-6)
+    # Per-pixel weighted average of displacements. Outside the tile envelope
+    # the field is identity, so cv2.remap passes lowres_aligned through.
+    weight_safe = np.maximum(weight_sum, 1e-6)
+    dy_field = dy_field_sum / weight_safe
+    dx_field = dx_field_sum / weight_safe
+    no_cov = weight_sum < 0.01
+    dy_field[no_cov] = 0.0
+    dx_field[no_cov] = 0.0
 
-    lowres_refined = warped_img_sum / weight_sum_safe
-
-    # Fill uncovered regions with original values
-    lowres_refined[no_coverage_mask] = lowres_aligned[no_coverage_mask]
-    # masks_result already has original values where no tile was applied (initialized from masks.copy())
-
-    # Ensure masks are integer type
-    masks_refined = masks_result.astype(masks.dtype)
+    yy_full, xx_full = np.mgrid[0:h, 0:w].astype(np.float32)
+    map_x = (xx_full + dx_field).astype(np.float32)
+    map_y = (yy_full + dy_field).astype(np.float32)
+    lowres_refined = cv2.remap(lowres_aligned.astype(np.float32), map_x, map_y,
+                               cv2.INTER_LINEAR, borderMode=cv2.BORDER_CONSTANT, borderValue=0)
+    masks_refined  = cv2.remap(masks, map_x, map_y,
+                               cv2.INTER_NEAREST, borderMode=cv2.BORDER_CONSTANT, borderValue=0).astype(masks.dtype)
 
     return masks_refined, lowres_refined, tile_results
 
@@ -1659,7 +1730,7 @@ def compute_tile_defaults(tile_size):
         return KNOWN[tile_size].copy()
 
     # Auto-compute from ratios observed across known sizes
-    min_cells = max(2, min(12, int(tile_size / 37)))
+    min_cells = max(2, min(6, int(tile_size / 50)))
     clamp_mult = max(1.1, min(2.5, 1.0 + tile_size / 300))
     border_spacing = max(30, min(200, int(tile_size * 0.35)))
 
@@ -1670,14 +1741,20 @@ def compute_tile_defaults(tile_size):
 
 def compute_adaptive_matching_params(cell_df, tile_size, stage_idx=0,
                                      percentile=95, multiplier=1.5,
-                                     tile_ratio=0.3, patch_ratio=2.0,
+                                     tile_ratio=0.4, patch_ratio=2.0,
                                      patch_tile_ratio=0.6,
+                                     z_tile_ratio=0.01,
                                      search_xy_min=3, search_xy_max=50,
-                                     search_z_default=2, search_z_fine=1):
+                                     search_z_min=2, search_z_max=5):
     """Compute adaptive search/patch sizes from current residual magnitudes.
 
-    For stage 0 (first cascade stage): uses tile-proportional defaults.
-    For subsequent stages: measures residuals from post-correction re-match.
+    For stage 0 (first cascade stage): uses tile-proportional defaults
+      - search_xy = tile_size * tile_ratio
+      - search_z  = max(search_z_min, round(tile_size * z_tile_ratio))
+    For subsequent stages: residual-driven from post-correction re-match
+      - search_xy = ceil(P95(|dxy|) * multiplier), capped at tile_size*tile_ratio and search_xy_max
+      - search_z  = ceil(P95(|dz|)  * multiplier), capped at search_z_max
+        (falls back to stage-0 proportional value if cell_df has no 'dz' column)
 
     Returns (patch_radius, search_xy, search_z).
     """
@@ -1685,22 +1762,30 @@ def compute_adaptive_matching_params(cell_df, tile_size, stage_idx=0,
         # First stage or no data: tile-proportional defaults
         patch_r = int(tile_size * patch_tile_ratio)
         search_xy = int(tile_size * tile_ratio)
-        search_z = search_z_default
+        search_z = max(search_z_min, int(round(tile_size * z_tile_ratio)))
         return patch_r, search_xy, search_z
 
     resid_mag = np.sqrt(cell_df.dy.values**2 + cell_df.dx.values**2)
-    p = np.percentile(resid_mag, percentile)
+    p_xy = np.percentile(resid_mag, percentile)
 
-    # Search range: enough to capture residuals with margin
-    search_xy = max(search_xy_min, int(np.ceil(p * multiplier)))
-    # Cap at fraction of tile size
+    # XY search: enough to capture residuals with margin
+    search_xy = max(search_xy_min, int(np.ceil(p_xy * multiplier)))
+    # Cap at fraction of tile size and absolute max
     search_xy = min(search_xy, int(tile_size * tile_ratio), search_xy_max)
     # Patch must be at least patch_ratio * search
     patch_radius = max(search_xy, int(search_xy * patch_ratio))
     # Cap at tile size
     patch_radius = min(patch_radius, tile_size)
 
-    search_z = search_z_fine
+    # Z search: residual-driven if dz residuals available, else tile-proportional fallback.
+    # The rematch's own search_z bounds what we can measure here, so this can saturate
+    # when residual z exceeds the rematch window.
+    if 'dz' in cell_df.columns:
+        p_z = np.percentile(np.abs(cell_df.dz.values), percentile)
+        search_z = max(1, int(np.ceil(p_z * multiplier)))
+    else:
+        search_z = max(search_z_min, int(round(tile_size * z_tile_ratio)))
+    search_z = min(search_z, search_z_max)
 
     return patch_radius, search_xy, search_z
 
@@ -2003,6 +2088,17 @@ def run_local_tile_ransac(twop_binary, hcr_3d_bin, z_map, centroids, cell_df,
                           min_iou=0.10, min_gain=0.04,
                           border_anchor_spacing=100,
                           smoothing=50,
+                          # Edge-correction knobs forwarded to _synthesize_warp_from_tiles.
+                          # Defaults preserve original conservative behavior.
+                          # use_nn_fallback=True eliminates the data-weight "snap to zero"
+                          # outside the accepted-tile envelope by blending to nearest-tile
+                          # shift instead — safe because NN value is bounded by per-tile
+                          # IoU + MAD checks the accepted tiles already passed.
+                          use_nn_fallback=False,
+                          data_sigma_mult=1.0,
+                          border_decay_mult=2.0,
+                          border_weight_floor=0.0,
+                          disable_border_anchors=False,
                           debug_dump_path=None):
     """Fit per-tile affines from cell matches, return smooth RBF displacement fields.
 
@@ -2057,7 +2153,7 @@ def run_local_tile_ransac(twop_binary, hcr_3d_bin, z_map, centroids, cell_df,
                     cand_dx = float(np.median(in_tile.dx.values))
                     cand_dz = float(np.median(in_tile.dz.values))
                 else:
-                    mc = np.array([[tc_y, tc_x, 1]])
+                    mc = np.array([tc_y, tc_x, 1])
                     cand_dy = float(mc @ A_dy)
                     cand_dx = float(mc @ A_dx)
                     cand_dz = float(mc @ A_dz)
@@ -2105,6 +2201,11 @@ def run_local_tile_ransac(twop_binary, hcr_3d_bin, z_map, centroids, cell_df,
         tile_results, ny, nx, tile_size,
         border_anchor_spacing=border_anchor_spacing,
         smoothing=smoothing,
+        use_nn_fallback=use_nn_fallback,
+        data_sigma_mult=data_sigma_mult,
+        border_decay_mult=border_decay_mult,
+        border_weight_floor=border_weight_floor,
+        disable_border_anchors=disable_border_anchors,
         n_iou_rejected=n_iou_rejected,
     )
     return dy_f, dx_f, dz_f, tile_results
@@ -2114,7 +2215,7 @@ def _synthesize_warp_from_tiles(
     tile_results, ny, nx, tile_size,
     border_anchor_spacing=100,
     smoothing=50,
-    mad_k=3.0,
+    mad_k=4.0,
     mad_floor=1.0,
     border_decay_mult=2.0,
     data_sigma_mult=1.0,

--- a/src/segmentation.py
+++ b/src/segmentation.py
@@ -1,8 +1,15 @@
 from collections import defaultdict
 from pathlib import Path
 import shutil
+import cellpose
 from cellpose import models
 from cellpose import io
+
+# Cellpose 3 (cyto/cyto3 U-Net) and cellpose 4 (cellpose-SAM, ViT) share most
+# of the eval signature but differ on `channels` (cp4 is single-channel by
+# design, no `channels` arg) and on `diameter` (cp4 auto-detects when omitted).
+# Branching once at import time keeps the call sites clean.
+_CP_MAJOR = int(cellpose.__version__.split('.')[0])
 import numpy as np
 import pandas as pd
 import scipy.io as sio
@@ -49,7 +56,12 @@ def _apply_neuropil_pooling(pooling_method: str, values: np.ndarray) -> np.ndarr
         raise ValueError(f"Unsupported pooling method: {pooling_method}")
 
 def _get_cached_cellpose_model(model_path: str, gpu: bool):
-    """Get or create a cached Cellpose model instance."""
+    """Get or create a cached Cellpose model instance.
+
+    Works for both cp3 (custom cyto-style checkpoint paths) and cp4
+    (`pretrained_model='cpsam'` for the SAM generalist, or a path to a
+    fine-tuned cpsam checkpoint).
+    """
     cache_key = (model_path, gpu)
     if cache_key not in _cellpose_model_cache:
         _cellpose_model_cache[cache_key] = models.CellposeModel(
@@ -57,6 +69,26 @@ def _get_cached_cellpose_model(model_path: str, gpu: bool):
             gpu=gpu
         )
     return _cellpose_model_cache[cache_key]
+
+
+def _eval_kwargs(cellpose_params: dict, do_3D: bool) -> dict:
+    """Build kwargs for `model.eval()` that work on both cellpose 3 and 4.
+
+    cp3: passes `channels=[0,0]` (DAPI-only grayscale) and `diameter` always.
+    cp4: drops `channels` (single-channel by SAM design); `diameter` is
+         passed only when set (None / null in manifest = auto-detect).
+    """
+    kw = dict(
+        flow_threshold=cellpose_params['flow_threshold'],
+        cellprob_threshold=cellpose_params['cellprob_threshold'],
+        do_3D=do_3D,
+    )
+    diameter = cellpose_params.get('diameter')
+    if diameter is not None:
+        kw['diameter'] = diameter
+    if _CP_MAJOR < 4:
+        kw['channels'] = [0, 0]
+    return kw
 
 # CellposeModelWrapper class
 # This class encapsulates the Cellpose model and its configuration.
@@ -80,11 +112,7 @@ class CellposeModelWrapper:
 
         return self.model.eval(
             raw_image,
-            channels=[0,0],
-            diameter=self.params['HCR_cellpose']['diameter'],
-            flow_threshold=self.params['HCR_cellpose']['flow_threshold'],
-            cellprob_threshold=self.params['HCR_cellpose']['cellprob_threshold'],
-            do_3D=True,
+            **_eval_kwargs(self.params['HCR_cellpose'], do_3D=True),
         )
 
 def run_cellpose(full_manifest):
@@ -143,11 +171,7 @@ def run_cellpose_2p(tiff_path: Path, output_path: Path, cellpose_params: dict):
 
     masks, flows, styles = model.eval(
         raw_image,
-        channels=[0, 0],
-        diameter=cellpose_params['diameter'],
-        flow_threshold=cellpose_params['flow_threshold'],
-        cellprob_threshold=cellpose_params['cellprob_threshold'],
-        do_3D=False,
+        **_eval_kwargs(cellpose_params, do_3D=False),
     )
 
     io.masks_flows_to_seg(raw_image, masks, flows, str(tiff_path.parent / tiff_path.stem), channels=[0,0])

--- a/src/segmentation.py
+++ b/src/segmentation.py
@@ -110,7 +110,7 @@ class CellposeModelWrapper:
         self.params = params
         self.model = None
 
-    def eval(self, raw_image):
+    def eval(self, raw_image, progress=None):
         if self.model is None:
             # Use cached model (optimization: reuse across pipeline)
             self.model = _get_cached_cellpose_model(
@@ -118,10 +118,10 @@ class CellposeModelWrapper:
                 self.params['HCR_cellpose']['gpu']
             )
 
-        return self.model.eval(
-            raw_image,
-            **_eval_kwargs(self.params['HCR_cellpose'], do_3D=True),
-        )
+        kw = _eval_kwargs(self.params['HCR_cellpose'], do_3D=True)
+        if progress is not None:
+            kw['progress'] = progress
+        return self.model.eval(raw_image, **kw)
 
 def run_cellpose(full_manifest):
     manifest = full_manifest['data']
@@ -153,21 +153,22 @@ def run_cellpose(full_manifest):
     model_wrapper = CellposeModelWrapper(params)
 
     # Disable the outer round-counter bar when there's only one round to process
-    # (cellpose itself prints per-slice progress during 3D inference, so the
-    # 0/1→1/1 round counter is just noise in the single-round case).
+    # (the per-slice intra-round bar below is more useful in that case).
     iterator = tqdm(to_process, desc="HCR cellpose", disable=len(to_process) <= 1)
     for HCR_round_to_register, round_folder_name in iterator:
         full_stack_path = output_root(full_manifest) / 'HCR' / 'full_registered_stacks' / f"{round_folder_name}.tiff"
         output_path = output_root(full_manifest) / 'HCR' / 'cellpose' / f"{round_folder_name}_masks.tiff"
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        if len(to_process) == 1:
-            rprint(f"  [dim]Cellpose on {round_folder_name}...[/dim]")
-
         raw_image = tif_imread(full_stack_path)
         cellpose_input = raw_image[:, cellpose_channel_index, :, :]
 
-        masks, _, _ = model_wrapper.eval(cellpose_input)
+        # Per-slice progress bar (cellpose ticks once per Z-slice during 3D
+        # inference). Useful for big HCR stacks that take 10s of minutes.
+        nz = cellpose_input.shape[0]
+        with tqdm(total=nz, desc=f"  {round_folder_name} (cellpose-SAM)",
+                  unit="slice", leave=False) as pb:
+            masks, _, _ = model_wrapper.eval(cellpose_input, progress=pb)
         tif_imsave(output_path, masks)
 
 def run_cellpose_2p(tiff_path: Path, output_path: Path, cellpose_params: dict):

--- a/src/segmentation.py
+++ b/src/segmentation.py
@@ -19,7 +19,7 @@ from scipy.spatial import ConvexHull
 from scipy.interpolate import LinearNDInterpolator
 from .registrations import verify_rounds
 from .functional import get_number_of_suite2p_planes
-from .meta import get_intensity_extraction_config, get_round_folder_name
+from .meta import get_intensity_extraction_config, get_round_folder_name, output_root
 
 
 
@@ -102,7 +102,7 @@ def run_cellpose(full_manifest):
     to_process = []
     for HCR_round_to_register in all_rounds:
         round_folder_name = get_round_folder_name(HCR_round_to_register, reference_round['round'])
-        output_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'HCR' / 'cellpose' / f"{round_folder_name}_masks.tiff"
+        output_path = output_root(full_manifest) / 'HCR' / 'cellpose' / f"{round_folder_name}_masks.tiff"
         if output_path.exists():
             skipped.append(round_folder_name)
         else:
@@ -117,8 +117,8 @@ def run_cellpose(full_manifest):
     model_wrapper = CellposeModelWrapper(params)
 
     for HCR_round_to_register, round_folder_name in tqdm(to_process, desc="HCR cellpose"):
-        full_stack_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'HCR' / 'full_registered_stacks' / f"{round_folder_name}.tiff"
-        output_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'HCR' / 'cellpose' / f"{round_folder_name}_masks.tiff"
+        full_stack_path = output_root(full_manifest) / 'HCR' / 'full_registered_stacks' / f"{round_folder_name}.tiff"
+        output_path = output_root(full_manifest) / 'HCR' / 'cellpose' / f"{round_folder_name}_masks.tiff"
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
         raw_image = tif_imread(full_stack_path)
@@ -163,7 +163,7 @@ def run_cellpose_2p(tiff_path: Path, output_path: Path, cellpose_params: dict):
 def extract_2p_cellpose_masks(full_manifest: dict, session: dict):
     manifest = full_manifest['data']
     params = full_manifest['params']
-    cellpose_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / '2P' / 'cellpose'
+    cellpose_path = output_root(full_manifest) / '2P' / 'cellpose'
 
     # Get the current plane being processed
     current_plane = session['functional_plane'][0]
@@ -313,7 +313,7 @@ def extract_probs_intensities(full_manifest):
             channels_names = reference_round['channels']
         else:
             channels_names = round_to_rounds[HCR_round_to_register]['channels']
-        output_folder = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'HCR' / 'extract_intensities'
+        output_folder = output_root(full_manifest) / 'HCR' / 'extract_intensities'
         pkl_output_path = output_folder / f"{round_folder_name}_probs_intensities.pkl"
         if not pkl_output_path.exists():
             to_process.append((HCR_round_to_register, round_folder_name, channels_names))
@@ -328,7 +328,7 @@ def extract_probs_intensities(full_manifest):
     # Pre-flight: check TIFF channel count vs manifest for all rounds (metadata-only, cheap)
     mismatches = []
     for _, round_folder_name, channels_names in to_process:
-        stack_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'HCR' / 'full_registered_stacks' / f"{round_folder_name}.tiff"
+        stack_path = output_root(full_manifest) / 'HCR' / 'full_registered_stacks' / f"{round_folder_name}.tiff"
         with TiffFile(stack_path) as tf:
             n_ch = tf.series[0].shape[1]
         if n_ch != len(channels_names):
@@ -354,9 +354,9 @@ def extract_probs_intensities(full_manifest):
         median_filter = np.ones((median_filter_config[0], 1, median_filter_config[1], median_filter_config[2]))
 
     for HCR_round_to_register, round_folder_name, channels_names in to_process:
-        full_stack_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'HCR' / 'full_registered_stacks' / f"{round_folder_name}.tiff"
-        full_stack_masks_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'HCR' / 'cellpose' / f"{round_folder_name}_masks.tiff"
-        output_folder = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'HCR' / 'extract_intensities'
+        full_stack_path = output_root(full_manifest) / 'HCR' / 'full_registered_stacks' / f"{round_folder_name}.tiff"
+        full_stack_masks_path = output_root(full_manifest) / 'HCR' / 'cellpose' / f"{round_folder_name}_masks.tiff"
+        output_folder = output_root(full_manifest) / 'HCR' / 'extract_intensities'
         output_folder.mkdir(parents=True, exist_ok=True)
         csv_output_path = output_folder / f"{round_folder_name}_probs_intensities.csv"
         pkl_output_path = output_folder / f"{round_folder_name}_probs_intensities.pkl"
@@ -457,8 +457,8 @@ def extract_electrophysiology_intensities(full_manifest: dict , session: dict):
     suite2p_run = session['functional_run'][0]
 
     suite2p_path = Path(manifest['base_path']) / manifest['mouse_name'] / '2P' /  f'{mouse_name}_{date}_{suite2p_run}' / 'suite2p'
-    save_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / '2P' / 'suite2p'
-    cellpose_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / '2P' / 'cellpose'
+    save_path = output_root(full_manifest) / '2P' / 'suite2p'
+    cellpose_path = output_root(full_manifest) / '2P' / 'cellpose'
     save_path.mkdir(exist_ok=True, parents=True)
     functional_plane = session['functional_plane'][0]
 
@@ -818,10 +818,10 @@ def align_masks(full_manifest: dict,
     round_to_rounds, reference_round, register_rounds = verify_rounds(full_manifest, parse_registered = True, 
                                                                     print_rounds = False, print_registered = False)
     
-    reference_round_tiff = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'HCR' / 'full_registered_stacks' / f"HCR{reference_round['round']}.tiff"
-    reference_round_masks = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'HCR' / 'cellpose' / f"HCR{reference_round['round']}_masks.tiff"
+    reference_round_tiff = output_root(full_manifest) / 'HCR' / 'full_registered_stacks' / f"HCR{reference_round['round']}.tiff"
+    reference_round_masks = output_root(full_manifest) / 'HCR' / 'cellpose' / f"HCR{reference_round['round']}_masks.tiff"
 
-    output_folder = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'MERGED' / 'aligned_masks'
+    output_folder = output_root(full_manifest) / 'MERGED' / 'aligned_masks'
     output_folder.mkdir(parents=True, exist_ok=True)
 
     # Collect matching results for summary
@@ -833,7 +833,7 @@ def align_masks(full_manifest: dict,
         for HCR_round_to_register in register_rounds:
             round_folder_name = get_round_folder_name(HCR_round_to_register, reference_round['round'])
 
-            mov_stack_masks = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'HCR' / 'cellpose' / f"{round_folder_name}_masks.tiff"
+            mov_stack_masks = output_root(full_manifest) / 'HCR' / 'cellpose' / f"{round_folder_name}_masks.tiff"
 
             save_path = output_folder / f"{round_folder_name}.csv"
             if save_path.exists():
@@ -870,7 +870,7 @@ def align_masks(full_manifest: dict,
     rprint("="*80)
 
     plane = session['functional_plane'][0]
-    reg_save_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / '2P' / 'registered'
+    reg_save_path = output_root(full_manifest) / '2P' / 'registered'
 
     # Use automated registration output (3D volume from twop_to_hcr_registration)
     masks_2p_aligned_3d_path = reg_save_path / f'twop_plane{plane}_aligned_3d.tiff'
@@ -928,9 +928,9 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
 
     round_to_rounds, reference_round, register_rounds = verify_rounds(full_manifest, parse_registered = True, 
                                                                     print_rounds = False, print_registered = False)
-    HCR_intensities_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'HCR' / 'extract_intensities'
-    HCR_mapping_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'MERGED' / 'aligned_masks'
-    merged_table_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / 'MERGED' / 'aligned_extracted_features'
+    HCR_intensities_path = output_root(full_manifest) / 'HCR' / 'extract_intensities'
+    HCR_mapping_path = output_root(full_manifest) / 'MERGED' / 'aligned_masks'
+    merged_table_path = output_root(full_manifest) / 'MERGED' / 'aligned_extracted_features'
     merged_table_path.mkdir(parents=True, exist_ok=True)
     
     # Check if median filter was applied

--- a/src/segmentation.py
+++ b/src/segmentation.py
@@ -23,12 +23,16 @@ from tifffile import imread as tif_imread
 from tifffile import imwrite as tif_imsave
 from tifffile import TiffFile
 from tqdm.auto import tqdm
-from rich import print as rprint
 from scipy.spatial import ConvexHull
 from scipy.interpolate import LinearNDInterpolator
-from .registrations import verify_rounds
-from .functional import get_number_of_suite2p_planes
-from .meta import get_intensity_extraction_config, get_round_folder_name, output_root
+try:
+    from .registrations import verify_rounds  # Relative import (running as part of a package)
+    from .functional import get_number_of_suite2p_planes
+    from .meta import get_intensity_extraction_config, get_round_folder_name, output_root, rprint
+except ImportError:
+    from registrations import verify_rounds  # Absolute import (running in Jupyter notebook)
+    from functional import get_number_of_suite2p_planes
+    from meta import get_intensity_extraction_config, get_round_folder_name, output_root, rprint
 
 
 
@@ -73,23 +77,30 @@ def _get_cached_cellpose_model(model_path: str, gpu: bool):
     return _cellpose_model_cache[cache_key]
 
 
-def _eval_kwargs(cellpose_params: dict, do_3D: bool) -> dict:
+# 3D HCR stacks are segmented as 2D-per-z + IoU stitching (do_3D=False,
+# stitch_threshold>0) rather than cellpose's do_3D=True orthogonal-flow merge.
+# do_3D=True produced choppy per-slice cross-sections on anisotropic confocal
+# data (z-step >> xy pixel). 0.3 is cellpose's default and was validated on JS078
+# DAPI in figure_notebooks/figure_4_cortex/cellpos4_smallchunk_fixing.ipynb.
+HCR_STITCH_THRESHOLD = 0.3
+
+
+def _eval_kwargs(cellpose_params: dict, is_3d_stack: bool) -> dict:
     """Build kwargs for `model.eval()` that work on both cellpose 3 and 4.
 
-    cp3: passes `channels=[0,0]` (DAPI-only grayscale) and `diameter` always.
-    cp4: drops `channels` (single-channel by SAM design); `diameter` is
-         passed only when set (None / null in manifest = auto-detect).
-    Both: when `do_3D=True`, pass `z_axis=0`. cp3 inferred this from the
-    image shape, but cp4 raises ValueError if z_axis is omitted on a 3D
-    array. The HCR pipeline always feeds a (Z, Y, X) array so z_axis=0 is
-    correct in both versions.
+    cp3 passes `channels=[0,0]` (DAPI-only grayscale); cp4 drops `channels`
+    (single-channel by SAM design). `diameter` is passed only when set
+    (None/null in manifest = cp4 auto-detect; cp3 falls back to its own
+    default). For 3D HCR stacks we always run in stitch mode -- see
+    HCR_STITCH_THRESHOLD above.
     """
     kw = dict(
         flow_threshold=cellpose_params['flow_threshold'],
         cellprob_threshold=cellpose_params['cellprob_threshold'],
-        do_3D=do_3D,
+        do_3D=False,
     )
-    if do_3D:
+    if is_3d_stack:
+        kw['stitch_threshold'] = HCR_STITCH_THRESHOLD
         kw['z_axis'] = 0
     diameter = cellpose_params.get('diameter')
     if diameter is not None:
@@ -97,6 +108,77 @@ def _eval_kwargs(cellpose_params: dict, do_3D: bool) -> dict:
     if _CP_MAJOR < 4:
         kw['channels'] = [0, 0]
     return kw
+
+
+# Outlier-size HCR mask filter. Thresholds are relative to the stack's
+# median so the rule self-calibrates across mice and microscopes.
+HCR_MASK_VOL_MIN_FRAC    = 0.1
+HCR_MASK_VOL_MAX_FRAC    = 10.0
+HCR_MASK_BBOX_MAX_FRAC   = 3.0
+HCR_MASK_MIN_N_FOR_STATS = 10
+
+
+def _filter_implausible_hcr_masks(masks: np.ndarray) -> tuple:
+    """Drop labels with vol < 0.1x or > 10x median, or xy bbox > 3x median bbox,
+    then relabel 1..N. Skipped if fewer than HCR_MASK_MIN_N_FOR_STATS labels.
+    Returns (masks, counts) with total/kept/tiny/huge_vol/huge_xy/median_vol/median_bbox.
+    """
+    from skimage.segmentation import relabel_sequential
+    from scipy.ndimage import find_objects
+
+    counts = dict(total=0, kept=0, tiny=0, huge_vol=0, huge_xy=0,
+                  median_vol=0.0, median_bbox=0.0)
+    if masks.max() == 0:
+        return masks, counts
+
+    vols   = np.bincount(masks.ravel())
+    slices = find_objects(masks)
+
+    present, bbox_ext = [], []
+    for lbl in range(1, len(vols)):
+        if vols[lbl] == 0:
+            continue
+        present.append(lbl)
+        sl = slices[lbl - 1]
+        bbox_ext.append(max(sl[1].stop - sl[1].start, sl[2].stop - sl[2].start)
+                        if sl is not None else 0)
+    present  = np.array(present, dtype=np.int64)
+    bbox_ext = np.array(bbox_ext, dtype=np.int64)
+    label_vols = vols[present]
+
+    counts['total'] = int(len(present))
+    if len(present) < HCR_MASK_MIN_N_FOR_STATS:
+        counts['kept'] = counts['total']
+        return masks, counts
+
+    med_vol  = float(np.median(label_vols))
+    med_bbox = float(np.median(bbox_ext))
+    counts['median_vol']  = med_vol
+    counts['median_bbox'] = med_bbox
+
+    min_vol      = HCR_MASK_VOL_MIN_FRAC  * med_vol
+    max_vol      = HCR_MASK_VOL_MAX_FRAC  * med_vol
+    max_bbox_ext = HCR_MASK_BBOX_MAX_FRAC * med_bbox
+
+    drop_mask = np.zeros(len(vols), dtype=bool)
+    for i, lbl in enumerate(present):
+        v = label_vols[i]
+        if v < min_vol:
+            drop_mask[lbl] = True; counts['tiny']     += 1; continue
+        if v > max_vol:
+            drop_mask[lbl] = True; counts['huge_vol'] += 1; continue
+        if bbox_ext[i] > max_bbox_ext:
+            drop_mask[lbl] = True; counts['huge_xy']  += 1
+
+    counts['kept'] = counts['total'] - counts['tiny'] - counts['huge_vol'] - counts['huge_xy']
+
+    if drop_mask.any():
+        zero_lookup = np.arange(len(vols), dtype=masks.dtype)
+        zero_lookup[drop_mask] = 0
+        filtered, _, _ = relabel_sequential(zero_lookup[masks])
+        return filtered.astype(masks.dtype), counts
+    return masks, counts
+
 
 # CellposeModelWrapper class
 # This class encapsulates the Cellpose model and its configuration.
@@ -118,7 +200,7 @@ class CellposeModelWrapper:
                 self.params['HCR_cellpose']['gpu']
             )
 
-        kw = _eval_kwargs(self.params['HCR_cellpose'], do_3D=True)
+        kw = _eval_kwargs(self.params['HCR_cellpose'], is_3d_stack=True)
         if progress is not None:
             kw['progress'] = progress
         return self.model.eval(raw_image, **kw)
@@ -169,6 +251,12 @@ def run_cellpose(full_manifest):
         with tqdm(total=nz, desc=f"  {round_folder_name} (cellpose-SAM)",
                   unit="slice", leave=False) as pb:
             masks, _, _ = model_wrapper.eval(cellpose_input, progress=pb)
+
+        masks, fc = _filter_implausible_hcr_masks(masks)
+        rprint(f"  {round_folder_name}: kept {fc['kept']}/{fc['total']} masks "
+               f"(dropped {fc['tiny']} tiny + {fc['huge_vol']} huge_vol + {fc['huge_xy']} huge_xy; "
+               f"median vol={fc['median_vol']:.0f} vox, bbox={fc['median_bbox']:.0f} px)")
+
         tif_imsave(output_path, masks)
 
 def run_cellpose_2p(tiff_path: Path, output_path: Path, cellpose_params: dict):
@@ -187,7 +275,7 @@ def run_cellpose_2p(tiff_path: Path, output_path: Path, cellpose_params: dict):
 
     masks, flows, styles = model.eval(
         raw_image,
-        **_eval_kwargs(cellpose_params, do_3D=False),
+        **_eval_kwargs(cellpose_params, is_3d_stack=False),
     )
 
     io.masks_flows_to_seg(raw_image, masks, flows, str(tiff_path.parent / tiff_path.stem), channels=[0,0])
@@ -304,35 +392,57 @@ def get_neuropil_mask_square(volume, radius, bound, inds):
     else:
         exclusion_zone = volume > 0
 
-    for mask_id in tqdm(unique_masks, desc="Computing neuropil regions"):
+    def _coords_for_mask(mask_id, r):
         mask_coords = []
-
-        # Get all z-planes where this mask appears
         z_planes = np.unique(inds[mask_id][0])
         for z in z_planes:
-            # Get mask center for this z-plane
             mask_points = (inds[mask_id][0] == z)
             if not np.any(mask_points):
                 continue
-
             mx = int(inds[mask_id][1][mask_points].mean())
             my = int(inds[mask_id][2][mask_points].mean())
-
-            # Define square region around cell center
-            x_min, x_max_local = max(mx-radius, 0), min(mx+radius, x_max)
-            y_min, y_max_local = max(my-radius, 0), min(my+radius, y_max)
-
-            # Valid neuropil = within square AND outside exclusion zone
-            # exclusion_zone includes all cells + `bound`-pixel buffer around them
+            x_min, x_max_local = max(mx-r, 0), min(mx+r, x_max)
+            y_min, y_max_local = max(my-r, 0), min(my+r, y_max)
             neuropil_points = ~exclusion_zone[z, x_min:x_max_local, y_min:y_max_local]
-
             if np.any(neuropil_points):
                 x_coords, y_coords = np.where(neuropil_points)
                 z_coords = np.full_like(x_coords, z)
                 mask_coords.append(np.stack([z_coords, x_coords + x_min, y_coords + y_min]))
-
         if mask_coords:
-            all_masks_locs[mask_id] = np.hstack(mask_coords).astype(np.int32)
+            return np.hstack(mask_coords).astype(np.int32)
+        return None
+
+    pending = []
+    for mask_id in tqdm(unique_masks, desc="Computing neuropil regions"):
+        coords = _coords_for_mask(mask_id, radius)
+        if coords is not None:
+            all_masks_locs[mask_id] = coords
+        else:
+            pending.append(mask_id)
+
+    # Expansion fallback: cells fully surrounded by other cells get the radius bumped
+    # by `expand_step` until valid neuropil pixels are found. Column names downstream
+    # still reflect the original `radius` — these are bookkept silently so the output
+    # schema stays consistent.
+    expand_step = 20
+    max_expansions = 50  # radius can grow up to radius + 1000 px; effectively unbounded
+    current_radius = radius
+    expansion = 0
+    while pending and expansion < max_expansions:
+        expansion += 1
+        current_radius += expand_step
+        next_pending = []
+        for mask_id in tqdm(pending, desc=f"Expanding neuropil to r={current_radius} for {len(pending)} cells"):
+            coords = _coords_for_mask(mask_id, current_radius)
+            if coords is not None:
+                all_masks_locs[mask_id] = coords
+            else:
+                next_pending.append(mask_id)
+        pending = next_pending
+
+    if pending:
+        # Should be effectively impossible — image is saturated with cells out to 1000+ px.
+        rprint(f"[red]  {len(pending)} cells still have no neuropil after expansion to r={current_radius}; they will be omitted.[/red]")
 
     return all_masks_locs
 
@@ -438,11 +548,18 @@ def extract_probs_intensities(full_manifest):
             neuropil_col_names[pooling_method] = col_suffix
 
         to_pnd = defaultdict(list)
+        skipped_no_neuropil = 0
         for mask_id, mask_inds in enumerate(tqdm(inds, desc=f"HCR {round_folder_name}")):
             if mask_id == 0:
                 continue
             if len(mask_inds[0]) == 0:
                 raise Exception("Mask with zero pixels")
+            # Cells fully surrounded by other cells within neuropil_radius+neuropil_boundary
+            # have no valid neuropil pixels; get_neuropil_mask_square omits them. Skip rather
+            # than crash — these cells get no intensity row at all.
+            if mask_id not in neuropil_masks_inds:
+                skipped_no_neuropil += 1
+                continue
             Z, Y, X = mask_inds
 
             vals_per_mask_per_channel = raw_image[Z, :, Y, X]
@@ -478,6 +595,9 @@ def extract_probs_intensities(full_manifest):
                     to_pnd[f'{median_filter_label}_{col_suffix}'].extend(
                         _apply_neuropil_pooling(pooling_method, neuropil_vals_per_channel_median)
                     )
+
+        if skipped_no_neuropil:
+            rprint(f"[yellow]  {round_folder_name}: skipped {skipped_no_neuropil} cells with no available neuropil region[/yellow]")
 
         #Save to `masks_path` folder
         df = pd.DataFrame(to_pnd)
@@ -563,12 +683,55 @@ def bigwarp_pixel_adjustment(stack1, stack2, name1="Stack1", name2="Stack2"):
 
 def match_masks(stack1_masks_path, stack2_masks_path):
     '''
-    Match masks between two registered stacks using IoU (Intersection over Union).
+    Match masks between two registered stacks and record several overlap
+    metrics per pair.
 
-    Returns DataFrame with columns: mask1, mask2, iou, is_best_match
-    - Records ALL overlapping pairs with their IoU scores
-    - is_best_match=True indicates the winning match (highest IoU, one-to-one)
-    - Users can filter to is_best_match==True for backward compatible behavior
+    Motivation
+    ----------
+    For 2P→HCR matching the source (stack1) is essentially a 2D sheet draped
+    in 3D space, while the target (stack2) is a full 3D HCR volume. A
+    symmetric IoU divides by |mask1| + |mask2| − overlap, so the 3D HCR
+    volume dominates the union and the IoU is structurally capped at
+    ~area_2P / volume_HCR (often ≤ 0.3 even for clean matches). Filtering
+    on that number is misleading. We additionally compute mask2's size
+    restricted to the z-slices that mask1 occupies, which gives a fair
+    apples-to-apples denominator. For HCR↔HCR (both 3D) the restriction is
+    a near-no-op.
+
+    Returns DataFrame with one row per overlapping (mask1, mask2) pair and
+    columns:
+
+      mask1, mask2
+          Label IDs in stack1 and stack2.
+      intersection
+          Overlap voxel count.
+      mask1_size
+          Total voxels in mask1.
+      mask2_size
+          Total voxels in mask2 (full 3D for HCR).
+      mask2_size_at_mask1_z
+          Voxels of mask2 restricted to the z-slices that contain mask1.
+          For 2P↔HCR: HCR cell's footprint at the 2P sheet's z-range.
+          For HCR↔HCR: ≈ mask2_size.
+      iou
+          Legacy 3D-symmetric IoU: intersection /
+          (mask1_size + mask2_size − intersection). Kept for backward
+          compat; depressed for 2P→HCR.
+      iou_at_mask1_z
+          Fair IoU using mask2_size_at_mask1_z as the mask2 denominator.
+          Drives is_best_match.
+      containment_2p
+          intersection / mask1_size. Fraction of mask1 explained by mask2.
+          Bounded [0, 1] regardless of dimensionality.
+      containment_hcr_at_z
+          intersection / mask2_size_at_mask1_z. Fraction of mask2 (at
+          mask1's z-range) explained by mask1.
+      is_best_match
+          True for the pair that wins the greedy 1:1 match, ranked by
+          iou_at_mask1_z.
+
+    For 2D inputs mask2_size_at_mask1_z == mask2_size and iou_at_mask1_z
+    == iou.
     '''
     stack1_masks = tif_imread(stack1_masks_path)
     stack2_masks = tif_imread(stack2_masks_path)
@@ -585,11 +748,28 @@ def match_masks(stack1_masks_path, stack2_masks_path):
 
     stack1_masks_inds = get_indices_sparse(stack1_masks.astype(np.uint16))
 
-    # OPTIMIZATION: Precompute all mask sizes in stack2 (avoids repeated full-image scans)
+    # Total mask2 voxels per ID (full volume).
     stack2_mask_ids, stack2_mask_sizes = np.unique(stack2_masks, return_counts=True)
     stack2_size_lookup = dict(zip(stack2_mask_ids, stack2_mask_sizes))
 
-    to_pandas = {'mask1': [], 'mask2': [], 'iou': []}
+    # Per-z mask2 voxel counts for the z-restricted denominator. Built once
+    # via np.bincount per z-slice; lookup per pair is then a small sum.
+    is_3d = stack2_masks.ndim == 3
+    if is_3d:
+        max_id_2 = int(stack2_masks.max())
+        nz = stack2_masks.shape[0]
+        mask2_size_per_z = np.zeros((nz, max_id_2 + 1), dtype=np.int64)
+        for z in range(nz):
+            mask2_size_per_z[z] = np.bincount(stack2_masks[z].ravel(),
+                                              minlength=max_id_2 + 1)
+
+    to_pandas = {
+        'mask1': [], 'mask2': [],
+        'intersection': [], 'mask1_size': [], 'mask2_size': [],
+        'mask2_size_at_mask1_z': [],
+        'iou': [], 'iou_at_mask1_z': [],
+        'containment_2p': [], 'containment_hcr_at_z': [],
+    }
 
     # Enumerate masks starting from 1 (index 0 is background)
     for mask1_id, mask1_inds in enumerate(stack1_masks_inds[1:], start=1):
@@ -604,23 +784,39 @@ def match_masks(stack1_masks_path, stack2_masks_path):
         if len(mask2_nonzero) == 0:
             continue  # No overlap with any mask2
 
+        # z-slices the mask1 voxels occupy (used for the fair denominator).
+        unique_zs = np.unique(mask1_inds[0]) if is_3d else None
+
         # Get all unique mask2 IDs that overlap with this mask1
         overlapping_mask2_ids = np.unique(mask2_nonzero)
 
-        # Calculate IoU for EACH overlapping mask2
         for mask2_id in overlapping_mask2_ids:
-            # Intersection: pixels where both mask1 and this mask2 are present
-            intersection = np.sum(mask2_at_mask1 == mask2_id)
+            intersection = int(np.sum(mask2_at_mask1 == mask2_id))
+            mask2_size = int(stack2_size_lookup.get(mask2_id, 0))
+            if is_3d:
+                mask2_size_at_mask1_z = int(mask2_size_per_z[unique_zs, mask2_id].sum())
+            else:
+                mask2_size_at_mask1_z = mask2_size
 
-            # Union: all pixels in mask1 + all pixels in mask2 - intersection
-            mask2_size = stack2_size_lookup.get(mask2_id, 0)
-            union = mask1_size + mask2_size - intersection
+            union_3d = mask1_size + mask2_size - intersection
+            union_at_z = mask1_size + mask2_size_at_mask1_z - intersection
 
-            iou = intersection / union if union > 0 else 0.0
+            iou = intersection / union_3d if union_3d > 0 else 0.0
+            iou_at_mask1_z = intersection / union_at_z if union_at_z > 0 else 0.0
+            containment_2p = intersection / mask1_size if mask1_size > 0 else 0.0
+            containment_hcr_at_z = (intersection / mask2_size_at_mask1_z
+                                    if mask2_size_at_mask1_z > 0 else 0.0)
 
             to_pandas['mask1'].append(mask1_id)
-            to_pandas['mask2'].append(mask2_id)
+            to_pandas['mask2'].append(int(mask2_id))
+            to_pandas['intersection'].append(intersection)
+            to_pandas['mask1_size'].append(mask1_size)
+            to_pandas['mask2_size'].append(mask2_size)
+            to_pandas['mask2_size_at_mask1_z'].append(mask2_size_at_mask1_z)
             to_pandas['iou'].append(iou)
+            to_pandas['iou_at_mask1_z'].append(iou_at_mask1_z)
+            to_pandas['containment_2p'].append(containment_2p)
+            to_pandas['containment_hcr_at_z'].append(containment_hcr_at_z)
 
     df = pd.DataFrame(to_pandas)
 
@@ -629,20 +825,18 @@ def match_masks(stack1_masks_path, stack2_masks_path):
         df['is_best_match'] = pd.Series(dtype=bool)
         return df
 
-    # Mark best matches: apply greedy 1:1 matching (highest IoU wins)
-    df = df.sort_values('iou', ascending=False).reset_index(drop=True)
+    # Greedy 1:1 best-match, ranked by the fair (z-restricted) IoU.
+    df = df.sort_values('iou_at_mask1_z', ascending=False).reset_index(drop=True)
 
-    # Track which matches are "best" (survive deduplication)
     df_best = df.drop_duplicates('mask2', keep='first').copy()
     df_best = df_best.drop_duplicates('mask1', keep='first')
 
-    # Use vectorized merge to mark best matches (much faster than df.apply for large DataFrames)
     df_best['is_best_match'] = True
     df = df.merge(df_best[['mask1', 'mask2', 'is_best_match']], on=['mask1', 'mask2'], how='left')
     df['is_best_match'] = df['is_best_match'].fillna(False)
 
-    # Sort by mask1, then by iou descending for readability
-    df = df.sort_values(['mask1', 'iou'], ascending=[True, False])
+    # Sort by mask1, then by fair IoU descending for readability
+    df = df.sort_values(['mask1', 'iou_at_mask1_z'], ascending=[True, False])
 
     return df
 
@@ -837,7 +1031,19 @@ def print_matching_summary(df: pd.DataFrame, source_name: str, target_name: str)
         rprint(f"    [yellow]Source masks with competition: {mask1_with_competition} (multiple targets)[/yellow]")
     if mask2_with_competition > 0:
         rprint(f"    [yellow]Target masks with competition: {mask2_with_competition} (multiple sources)[/yellow]")
-    rprint(f"    IoU range: {iou_min:.3f} - {iou_max:.3f} (median: {iou_median:.3f})")
+    rprint(f"    IoU (3D) range: {iou_min:.3f} - {iou_max:.3f} (median: {iou_median:.3f})")
+
+    # Fair (z-restricted) IoU and containment — informative for 2P→HCR where
+    # the 3D-symmetric IoU is depressed by the asymmetric union.
+    if n_best > 0 and 'iou_at_mask1_z' in best_matches.columns:
+        ioz_min = best_matches['iou_at_mask1_z'].min()
+        ioz_max = best_matches['iou_at_mask1_z'].max()
+        ioz_median = best_matches['iou_at_mask1_z'].median()
+        rprint(f"    IoU @ mask1 z range: {ioz_min:.3f} - {ioz_max:.3f} "
+               f"(median: {ioz_median:.3f})")
+    if n_best > 0 and 'containment_2p' in best_matches.columns:
+        c_median = best_matches['containment_2p'].median()
+        rprint(f"    Containment (mask1 in mask2) median: {c_median:.3f}")
 
 
 def align_masks(full_manifest: dict,
@@ -879,7 +1085,8 @@ def align_masks(full_manifest: dict,
             if save_path.exists():
                 existing_df = pd.read_csv(save_path)
                 # Check if file has all required columns; regenerate if stale
-                if 'iou' in existing_df.columns and 'is_best_match' in existing_df.columns:
+                if ({'iou', 'iou_at_mask1_z', 'is_best_match'}
+                        .issubset(existing_df.columns)):
                     rprint(f"  [dim]{round_folder_name}: mask alignment exists[/dim]")
                     matching_results.append((f"HCR{HCR_round_to_register}", f"HCR{reference_round['round']}", existing_df))
                     continue
@@ -924,7 +1131,8 @@ def align_masks(full_manifest: dict,
     save_path = output_folder / f"twop_plane{plane}_to_HCR{reference_round['round']}.csv"
     if save_path.exists():
         existing_df = pd.read_csv(save_path)
-        if 'iou' in existing_df.columns and 'is_best_match' in existing_df.columns:
+        if ({'iou', 'iou_at_mask1_z', 'is_best_match'}
+                .issubset(existing_df.columns)):
             rprint(f"[dim]2P masks alignment for plane {plane}: exists, skipping[/dim]")
             matching_results.append((f"2P plane {plane}", f"HCR{reference_round['round']}", existing_df))
         else:
@@ -952,6 +1160,125 @@ def align_masks(full_manifest: dict,
     rprint("\n" + "="*80)
     rprint("[bold green] Align 2P Masks COMPLETE[/bold green]")
     rprint("="*80 + "\n")
+
+
+def align_somaprint(full_manifest: dict, session: dict, only_hcr: bool = False):
+    """Run somaprint on the current 2P plane and merge its picks into the
+    existing IoU mask-matching CSV.
+
+    Somaprint is a geometric (neighbor-vector) matcher independent of IoU.
+    The result is denormalized as columns on the existing per-pair CSV:
+    every IoU candidate row for a given mask1 carries that mask1's
+    somaprint pick (somaprint_hcr_label, best/2nd score, confident bool).
+    For the rare 2P cell that somaprint confidently matches but has no
+    IoU overlap with any HCR mask, one synthetic row is appended (IoU=0,
+    is_best_match=False) so the pick stays queryable.
+
+    No-ops when only_hcr=True (no 2P plane), params.somaprint.enabled is
+    False, or the target CSV already has the somaprint columns.
+    """
+    from . import somaprint as sp_lib
+
+    if only_hcr:
+        return
+
+    sp_params = sp_lib.get_params(full_manifest)
+    if not sp_params.get('enabled', True):
+        rprint("[dim]Somaprint disabled (params.somaprint.enabled = false); skipping[/dim]")
+        return
+
+    _, reference_round, _ = verify_rounds(full_manifest, parse_registered=True,
+                                          print_rounds=False, print_registered=False)
+    plane = session['functional_plane'][0]
+    hcr_round = reference_round['round']
+    csv_path = (output_root(full_manifest) / 'MERGED' / 'aligned_masks'
+                / f"twop_plane{plane}_to_HCR{hcr_round}.csv")
+
+    if not csv_path.exists():
+        rprint(f"[yellow]Somaprint: IoU CSV missing at {csv_path}; "
+               f"align_masks must run first.[/yellow]")
+        return
+
+    df = pd.read_csv(csv_path)
+    # Strip any pre-existing leading index column (legacy CSVs saved without
+    # index=False); column-name access works regardless but accumulating
+    # 'Unnamed: 0' columns on every re-save is ugly.
+    df = df.loc[:, ~df.columns.str.match(r'^Unnamed: \d+$')]
+
+    if 'somaprint_confident' in df.columns:
+        rprint(f"[dim]Somaprint columns already present in {csv_path.name}; skipping[/dim]")
+        return
+
+    rprint("\n" + "="*80)
+    rprint(f"[bold green] Somaprint Matching (2P plane {plane} -> HCR{hcr_round})[/bold green]")
+    rprint("="*80)
+
+    matches = sp_lib.run_for_plane(full_manifest, session, hcr_round)
+
+    # Denormalize per-mask1: every row of a given mask1 carries that 2P
+    # cell's somaprint pick. Cells somaprint didn't return at all stay NaN.
+    hcr_label_by_m1 = {m1: v[0] for m1, v in matches.items()}
+    best_by_m1 = {m1: v[1] for m1, v in matches.items()}
+    second_by_m1 = {m1: v[2] for m1, v in matches.items()}
+    conf_by_m1 = {m1: v[3] for m1, v in matches.items()}
+
+    df['somaprint_hcr_label'] = df['mask1'].map(hcr_label_by_m1).astype('Int64')
+    df['somaprint_best_score'] = df['mask1'].map(best_by_m1)
+    df['somaprint_second_score'] = df['mask1'].map(second_by_m1)
+    df['somaprint_confident'] = df['mask1'].map(conf_by_m1).fillna(False).astype(bool)
+
+    # Edge case: 2P cells somaprint matched that don't appear in the IoU
+    # CSV at all (zero overlap with every HCR mask). Append synthetic rows
+    # so the pick propagates into the merged feature table. Typically 0-5
+    # cells per plane on JS078.
+    existing_mask1 = set(df['mask1'].astype(int).unique()) if not df.empty else set()
+    orphan_m1s = [int(m1) for m1 in matches.keys() if int(m1) not in existing_mask1]
+
+    if orphan_m1s:
+        # 3D voxel counts in the registered volumes — match match_masks'
+        # definition of mask1_size / mask2_size so the orphan rows are
+        # informationally consistent with the rest of the CSV.
+        twop_3d_path = (output_root(full_manifest) / '2P' / 'registered'
+                        / f'twop_plane{plane}_aligned_3d.tiff')
+        hcr_masks_path = (output_root(full_manifest) / 'HCR' / 'cellpose'
+                          / f'HCR{hcr_round}_masks.tiff')
+        twop_3d = tif_imread(str(twop_3d_path))
+        hcr_3d = tif_imread(str(hcr_masks_path))
+        tw_ids, tw_counts = np.unique(twop_3d, return_counts=True)
+        hc_ids, hc_counts = np.unique(hcr_3d, return_counts=True)
+        twop_size_by_lbl = dict(zip(map(int, tw_ids), map(int, tw_counts)))
+        hcr_size_by_lbl = dict(zip(map(int, hc_ids), map(int, hc_counts)))
+
+        orphan_rows = []
+        for m1 in orphan_m1s:
+            hcr_lbl, bs, ss, conf = matches[m1]
+            orphan_rows.append({
+                'mask1': int(m1),
+                'mask2': int(hcr_lbl),
+                'intersection': 0,
+                'mask1_size': twop_size_by_lbl.get(int(m1), 0),
+                'mask2_size': hcr_size_by_lbl.get(int(hcr_lbl), 0),
+                'mask2_size_at_mask1_z': 0,
+                'iou': 0.0,
+                'iou_at_mask1_z': 0.0,
+                'containment_2p': 0.0,
+                'containment_hcr_at_z': 0.0,
+                'is_best_match': False,
+                'somaprint_hcr_label': int(hcr_lbl),
+                'somaprint_best_score': float(bs) if np.isfinite(bs) else np.nan,
+                'somaprint_second_score': float(ss) if np.isfinite(ss) else np.nan,
+                'somaprint_confident': bool(conf),
+            })
+        df = pd.concat([df, pd.DataFrame(orphan_rows)], ignore_index=True)
+        df['somaprint_hcr_label'] = df['somaprint_hcr_label'].astype('Int64')
+
+    df = df.sort_values(['mask1', 'iou_at_mask1_z'], ascending=[True, False]).reset_index(drop=True)
+    df.to_csv(csv_path, index=False)
+
+    n_conf = int(df['somaprint_confident'].sum())
+    extra = f" (+{len(orphan_m1s)} non-IoU picks)" if orphan_m1s else ""
+    rprint(f"[green]✓ Somaprint integrated into {csv_path.name}: "
+           f"{n_conf} confident matches{extra}[/green]")
 
 
 def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
@@ -1020,12 +1347,72 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
 
     rprint(f"[bold]Building merged tables[/bold] ({len(features_to_extract)} features)")
 
+    # Metrics propagated from each mask-matching CSV into the merged table.
+    # Source of these columns is match_masks() in this file — see its
+    # docstring for the definitions. The merged table uses at-plane / at-z
+    # semantics throughout (plane-restricted for 2P↔HCR, ≈full-multiplane
+    # for HCR↔HCR), so the legacy 3D `iou`, the per-pair `mask2_size*`
+    # columns, and the derivable `intersection` are dropped on the way in;
+    # the survivors are the four below.
+    METRIC_COLUMNS = (
+        'iou_at_mask1_z',
+        'containment_2p', 'containment_hcr_at_z',
+        'mask1_size',
+    )
+
+    def _build_lookup_dicts(matching_df):
+        """Return (mask2 → mask1) dict plus a {metric: {mask2 → value}} map."""
+        mapping = {m2: m1 for m1, m2 in matching_df[['mask1', 'mask2']].values}
+        metrics = {}
+        for col in METRIC_COLUMNS:
+            if col in matching_df.columns:
+                metrics[col] = dict(zip(matching_df['mask2'].values,
+                                        matching_df[col].values))
+            else:
+                # Legacy CSV that predates a column — propagate None so the
+                # merged table is schema-stable; users see missing data
+                # rather than a hard failure.
+                metrics[col] = {}
+        return mapping, metrics
+
+    def _build_somaprint_lookups(matching_df):
+        """Return (somaprint_hcr_label → mask1) plus {metric: {label → value}}
+        for confident somaprint matches. Keyed on the somaprint pick
+        (parallel to the IoU lookup's mask2 key) so each HCR cell row in
+        the reference intensities table can fetch its somaprint partner.
+
+        Somaprint denormalizes per-mask1 across IoU candidate rows; we
+        dedupe on mask1 first. Returns empty dicts on legacy CSVs that
+        predate the somaprint columns.
+        """
+        if not {'somaprint_confident', 'somaprint_hcr_label'}.issubset(matching_df.columns):
+            return {}, {}
+        soma = (matching_df[matching_df['somaprint_confident'] == True]  # noqa: E712
+                .drop_duplicates('mask1'))
+        if soma.empty:
+            return {}, {}
+        soma_lbls = soma['somaprint_hcr_label'].astype(int)
+        mapping = dict(zip(soma_lbls, soma['mask1'].astype(int)))
+        # mask1_size on a somaprint_confident row is the 2P partner's size
+        # (match_masks fills it on IoU rows; align_somaprint fills it on
+        # orphan rows from a fresh tiff read — both definitions are 3D
+        # voxel counts in the registered 2P volume, which equals the 2P
+        # cell's 2D pixel count by sheet-into-3D construction).
+        metrics = {
+            'somaprint_best_score': dict(zip(soma_lbls, soma['somaprint_best_score'].astype(float))),
+            'somaprint_second_score': dict(zip(soma_lbls, soma['somaprint_second_score'].astype(float))),
+            'somaprint_mask_size': dict(zip(soma_lbls, soma['mask1_size'].astype(int))),
+        }
+        return mapping, metrics
+
     # ========== PRE-LOAD ALL DATA ONCE (optimization: avoid reloading per feature) ==========
 
     # Pre-load 2P mapping (feature-independent)
     if only_hcr:
         twoP_mapping_dict = {}
-        twoP_iou_dict = {}
+        twoP_metrics_dict = {col: {} for col in METRIC_COLUMNS}
+        twoP_soma_mapping_dict = {}
+        twoP_soma_metrics_dict = {}
     else:
         twop_mapping_path = HCR_mapping_path / f"twop_plane{plane}_to_HCR{reference_round['round']}.csv"
         try:
@@ -1035,15 +1422,18 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
                 f"2P-to-HCR mapping file not found: {twop_mapping_path}\n"
                 f"Please ensure align_masks() has completed successfully for plane {plane}."
             )
+        # Somaprint columns denormalize per-mask1; build lookups from the
+        # unfiltered df *before* narrowing to IoU best-match rows.
+        twoP_soma_mapping_dict, twoP_soma_metrics_dict = _build_somaprint_lookups(towP_to_reference_mapping)
+
         if 'is_best_match' in towP_to_reference_mapping.columns:
             towP_to_reference_mapping = towP_to_reference_mapping[towP_to_reference_mapping['is_best_match'] == True]
         if towP_to_reference_mapping.empty:
             rprint(f"[yellow]Warning: No 2P-to-HCR matches found for plane {plane}. All cells will have None for 2P mapping.[/yellow]")
             twoP_mapping_dict = {}
-            twoP_iou_dict = {}
+            twoP_metrics_dict = {col: {} for col in METRIC_COLUMNS}
         else:
-            twoP_mapping_dict = {mask_2:mask_1 for mask_1,mask_2 in towP_to_reference_mapping[['mask1','mask2']].values}
-            twoP_iou_dict = {mask_2:iou for mask_2,iou in towP_to_reference_mapping[['mask2','iou']].values}
+            twoP_mapping_dict, twoP_metrics_dict = _build_lookup_dicts(towP_to_reference_mapping)
 
     # Pre-load reference round intensities (full DataFrame, pivot per feature)
     ref_intensities_path = HCR_intensities_path / f"HCR{reference_round['round']}_probs_intensities.pkl"
@@ -1058,7 +1448,7 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
     # Pre-load HCR round mappings and intensities (feature-independent)
     HCR_rounds_names = register_rounds
     HCR_round_mapping_dict = []
-    HCR_round_iou_dict = []
+    HCR_round_metrics_dict = []
     preloaded_round_intensities = {}
 
     for HCR_round_to_register in register_rounds:
@@ -1075,8 +1465,9 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
             )
         if 'is_best_match' in round_mapping_df.columns:
             round_mapping_df = round_mapping_df[round_mapping_df['is_best_match'] == True]
-        HCR_round_mapping_dict.append({mask_2:mask_1 for mask_1,mask_2 in round_mapping_df[['mask1','mask2']].values})
-        HCR_round_iou_dict.append({mask_2:iou for mask_2,iou in round_mapping_df[['mask2','iou']].values})
+        round_mapping, round_metrics = _build_lookup_dicts(round_mapping_df)
+        HCR_round_mapping_dict.append(round_mapping)
+        HCR_round_metrics_dict.append(round_metrics)
 
         # Load intensities
         round_intensities_path = HCR_intensities_path / f"{round_file_name}_probs_intensities.pkl"
@@ -1114,33 +1505,92 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
         ####       ####
         ###  MATCH  ###
         ####       ####
-        # first let's match the 2p
-        mask_tp_matched = []
-        mask_tp_iou = []
-        for i in reference_round_intensities_pivot.mask_id_main:
-            if i in twoP_mapping_dict:
-                mask_tp_matched.append(twoP_mapping_dict[i])
-                mask_tp_iou.append(twoP_iou_dict[i])
-            else:
-                mask_tp_matched.append(None)
-                mask_tp_iou.append(None)
-        reference_round_intensities_pivot['twoP_mask'] = mask_tp_matched
-        reference_round_intensities_pivot['twoP_iou'] = mask_tp_iou
+        # Column naming in the merged table. All size / IoU / containment
+        # values are plane-restricted (at-plane for 2P↔HCR; ≈full-multiplane
+        # for HCR↔HCR). Subject of `containment` is named first
+        # (X_containment = fraction of X inside its partner). Unprefixed
+        # twoP_* = IoU side; twoP_somaprint_* = soma side.
+        #
+        # 2P↔HCR (IoU best-match):
+        #   twoP_mask, twoP_iou, twoP_containment, HCR_containment,
+        #   twoP_mask_size
+        # 2P↔HCR (somaprint, geometric matcher):
+        #   twoP_somaprint_mask, twoP_somaprint_best_score,
+        #   twoP_somaprint_second_score, twoP_somaprint_mask_size
+        # HCR-level (matcher-independent):
+        #   HCR_mask_size
+        # HCR round-to-round, one set per non-reference round R:
+        #   round_{R}_mask, round_{R}_iou, round_{R}_containment,
+        #   main_containment_round_{R}, round_{R}_mask_size
+        #
+        # See match_masks() and align_somaprint() docstrings for the
+        # precise definition of each metric. `mask_id_main` always refers
+        # to mask2 in the matching CSVs (the reference round = stack2).
+        TWOP_COL_RENAME = {
+            'iou_at_mask1_z':         'twoP_iou',
+            'containment_2p':         'twoP_containment',
+            'containment_hcr_at_z':   'HCR_containment',
+            'mask1_size':             'twoP_mask_size',
+        }
 
+        def _round_col(metric, round_name):
+            return {
+                'iou_at_mask1_z':         f'round_{round_name}_iou',
+                'containment_2p':         f'round_{round_name}_containment',
+                'containment_hcr_at_z':   f'main_containment_round_{round_name}',
+                'mask1_size':             f'round_{round_name}_mask_size',
+            }[metric]
+
+        def _lookup_column(mask_ids, dct):
+            """Map an iterable of mask_id_main values through a dict (None if missing)."""
+            return [dct.get(i) for i in mask_ids]
+
+        ref_mask_ids = reference_round_intensities_pivot.mask_id_main
+
+        # HCR cell size at the warped 2P plane — always populated (matcher-
+        # independent). Drives downstream sliver filtering. In only_hcr mode
+        # there is no 2P plane to project against; fall back to full 3D
+        # voxel counts so the column has stable semantics within the table.
+        from . import somaprint as sp_lib
+        if only_hcr:
+            hcr_size_lookup = sp_lib.compute_full_hcr_sizes(
+                full_manifest, reference_round['round'])
+        else:
+            hcr_size_lookup = sp_lib.compute_plane_projected_hcr_sizes(
+                full_manifest, session, reference_round['round'])
+        reference_round_intensities_pivot['HCR_mask_size'] = _lookup_column(
+            ref_mask_ids, hcr_size_lookup)
+
+        # 2P columns — IoU best-match path
+        reference_round_intensities_pivot['twoP_mask'] = _lookup_column(ref_mask_ids, twoP_mapping_dict)
+        for src_col, dest_col in TWOP_COL_RENAME.items():
+            reference_round_intensities_pivot[dest_col] = _lookup_column(
+                ref_mask_ids, twoP_metrics_dict.get(src_col, {}))
+
+        # 2P columns — somaprint side (geometric matcher, independent of
+        # IoU). For each HCR cell, twoP_somaprint_mask is the 2P cell that
+        # somaprint confidently matched here (None if no somaprint match
+        # landed on this HCR cell). twoP_mask and twoP_somaprint_mask can
+        # disagree; downstream consumers pick which matcher to filter on.
+        reference_round_intensities_pivot['twoP_somaprint_mask'] = _lookup_column(
+            ref_mask_ids, twoP_soma_mapping_dict)
+        reference_round_intensities_pivot['twoP_somaprint_best_score'] = _lookup_column(
+            ref_mask_ids, twoP_soma_metrics_dict.get('somaprint_best_score', {}))
+        reference_round_intensities_pivot['twoP_somaprint_second_score'] = _lookup_column(
+            ref_mask_ids, twoP_soma_metrics_dict.get('somaprint_second_score', {}))
+        reference_round_intensities_pivot['twoP_somaprint_mask_size'] = _lookup_column(
+            ref_mask_ids, twoP_soma_metrics_dict.get('somaprint_mask_size', {}))
+
+        # HCR round columns
         for j in range(len(HCR_round_mapping_dict)):
             HCR_main_2_HCR_round = HCR_round_mapping_dict[j]
-            HCR_main_2_HCR_round_iou = HCR_round_iou_dict[j]
-            mask_matched = []
-            mask_iou = []
-            for i in reference_round_intensities_pivot.mask_id_main:
-                if i in HCR_main_2_HCR_round:
-                    mask_matched.append(HCR_main_2_HCR_round[i])
-                    mask_iou.append(HCR_main_2_HCR_round_iou[i])
-                else:
-                    mask_matched.append(None)
-                    mask_iou.append(None)
-            reference_round_intensities_pivot[f'mask_round_{HCR_rounds_names[j]}'] = mask_matched
-            reference_round_intensities_pivot[f'iou_round_{HCR_rounds_names[j]}'] = mask_iou
+            round_metrics = HCR_round_metrics_dict[j]
+            round_name = HCR_rounds_names[j]
+            reference_round_intensities_pivot[f'round_{round_name}_mask'] = _lookup_column(
+                ref_mask_ids, HCR_main_2_HCR_round)
+            for src_col in METRIC_COLUMNS:
+                reference_round_intensities_pivot[_round_col(src_col, round_name)] = _lookup_column(
+                    ref_mask_ids, round_metrics.get(src_col, {}))
 
         ####       ####
         ###  MERGE  ###
@@ -1148,7 +1598,7 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
         HCR_main_pivot_merged = reference_round_intensities_pivot.copy().reset_index()
 
         for j in range(len(HCR_round_mapping_dict)):
-            round_mask_name = f'mask_round_{HCR_rounds_names[j]}'
+            round_mask_name = f'round_{HCR_rounds_names[j]}_mask'
 
             # Skip merge if the intensities DataFrame is empty (feature was missing for this round)
             if HCR_rounds_intensities_pivot[j].empty:
@@ -1171,3 +1621,50 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
     rprint("\n" + "="*80)
     rprint("[bold green] Match Aligned Masks COMPLETE[/bold green]")
     rprint("="*80 + "\n")
+
+
+def print_match_summary(full_manifest: dict, all_planes: list):
+    """One-line per-plane summary of 2P→HCR match counts.
+
+    Reports somaprint matches (primary) and IoU matches (parenthetical),
+    then how many of the somaprint matches carry through to each non-
+    reference HCR round. No-op for planes whose merged table or 2P
+    seg.npy is missing.
+    """
+    _, reference_round, register_rounds = verify_rounds(
+        full_manifest, parse_registered=True,
+        print_rounds=False, print_registered=False, func='match-summary')
+    ref = reference_round['round']
+
+    merged_dir = output_root(full_manifest) / 'MERGED' / 'aligned_extracted_features'
+    cellpose_dir = output_root(full_manifest) / '2P' / 'cellpose'
+
+    rprint("\n[bold cyan]2P→HCR match summary[/bold cyan]")
+    for plane in all_planes:
+        seg_path = cellpose_dir / f'lowres_meanImg_C0_plane{plane}_seg.npy'
+        merged_files = sorted(merged_dir.glob(f'full_table_*_twop_plane{plane}.pkl'))
+        if not merged_files:
+            rprint(f"  [yellow]Plane {plane}: merged table not found[/yellow]")
+            continue
+
+        if seg_path.exists():
+            stats = np.load(seg_path, allow_pickle=True).item()
+            total_2p = int(len(np.unique(stats['masks'])) - 1)
+            denom = str(total_2p)
+        else:
+            denom = "?"
+
+        df = pd.read_pickle(merged_files[0])
+        soma_matched = df['twoP_somaprint_mask'].notna() if 'twoP_somaprint_mask' in df.columns else None
+        n_soma = int(soma_matched.sum()) if soma_matched is not None else 0
+        n_iou = int(df['twoP_mask'].notna().sum()) if 'twoP_mask' in df.columns else 0
+
+        line = (f"  Plane {plane}: {n_soma}/{denom} 2P masks matched HCR{ref} "
+                f"(somaprint; IoU: {n_iou})")
+        if soma_matched is not None:
+            for r in register_rounds:
+                col = f'round_{r}_mask'
+                if col in df.columns:
+                    in_round = int((soma_matched & df[col].notna()).sum())
+                    line += f" → HCR{r}: {in_round}"
+        rprint(line)

--- a/src/segmentation.py
+++ b/src/segmentation.py
@@ -152,10 +152,17 @@ def run_cellpose(full_manifest):
     rprint(f"HCR cellpose: processing {len(to_process)}/{len(all_rounds)} rounds")
     model_wrapper = CellposeModelWrapper(params)
 
-    for HCR_round_to_register, round_folder_name in tqdm(to_process, desc="HCR cellpose"):
+    # Disable the outer round-counter bar when there's only one round to process
+    # (cellpose itself prints per-slice progress during 3D inference, so the
+    # 0/1→1/1 round counter is just noise in the single-round case).
+    iterator = tqdm(to_process, desc="HCR cellpose", disable=len(to_process) <= 1)
+    for HCR_round_to_register, round_folder_name in iterator:
         full_stack_path = output_root(full_manifest) / 'HCR' / 'full_registered_stacks' / f"{round_folder_name}.tiff"
         output_path = output_root(full_manifest) / 'HCR' / 'cellpose' / f"{round_folder_name}_masks.tiff"
         output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if len(to_process) == 1:
+            rprint(f"  [dim]Cellpose on {round_folder_name}...[/dim]")
 
         raw_image = tif_imread(full_stack_path)
         cellpose_input = raw_image[:, cellpose_channel_index, :, :]

--- a/src/segmentation.py
+++ b/src/segmentation.py
@@ -1,15 +1,17 @@
 from collections import defaultdict
 from pathlib import Path
 import shutil
-import cellpose
 from cellpose import models
 from cellpose import io
 
 # Cellpose 3 (cyto/cyto3 U-Net) and cellpose 4 (cellpose-SAM, ViT) share most
 # of the eval signature but differ on `channels` (cp4 is single-channel by
 # design, no `channels` arg) and on `diameter` (cp4 auto-detects when omitted).
-# Branching once at import time keeps the call sites clean.
-_CP_MAJOR = int(cellpose.__version__.split('.')[0])
+# Branching once at import time keeps the call sites clean. Use
+# importlib.metadata since cellpose 4 doesn't expose `__version__` on the
+# top-level module.
+from importlib.metadata import version as _pkg_version
+_CP_MAJOR = int(_pkg_version('cellpose').split('.')[0])
 import numpy as np
 import pandas as pd
 import scipy.io as sio

--- a/src/segmentation.py
+++ b/src/segmentation.py
@@ -79,12 +79,18 @@ def _eval_kwargs(cellpose_params: dict, do_3D: bool) -> dict:
     cp3: passes `channels=[0,0]` (DAPI-only grayscale) and `diameter` always.
     cp4: drops `channels` (single-channel by SAM design); `diameter` is
          passed only when set (None / null in manifest = auto-detect).
+    Both: when `do_3D=True`, pass `z_axis=0`. cp3 inferred this from the
+    image shape, but cp4 raises ValueError if z_axis is omitted on a 3D
+    array. The HCR pipeline always feeds a (Z, Y, X) array so z_axis=0 is
+    correct in both versions.
     """
     kw = dict(
         flow_threshold=cellpose_params['flow_threshold'],
         cellprob_threshold=cellpose_params['cellprob_threshold'],
         do_3D=do_3D,
     )
+    if do_3D:
+        kw['z_axis'] = 0
     diameter = cellpose_params.get('diameter')
     if diameter is not None:
         kw['diameter'] = diameter

--- a/src/somaprint.py
+++ b/src/somaprint.py
@@ -1,0 +1,703 @@
+"""2P-to-HCR cell matching via local geometric soma fingerprint.
+
+Each 2P cell is fingerprinted by the vectors to its m nearest neighbors.
+Candidate HCR partners (within a distance radius) are scored by greedy
+pairwise vector alignment plus a distance penalty. A GMM separates the
+per-cell best-score distribution into 'correct match' vs 'mismatch'
+components; the mismatch null is anchored by the second-best score
+distribution and a likelihood ratio decides which matches are confident.
+A small number of refinement rounds re-scores using only confirmed
+identity-paired neighbors instead of geometric neighbors.
+
+Validated against the IoU baseline on JS078 (98-99% concordance at
+IoU>=0, zero FAR-disagreements; see
+figure_notebooks/figure_4_cortex/somaprint_tests/somaprint_cross_mouse.ipynb).
+Inputs come from twop_to_hcr_registration outputs
+(twop_plane{P}_aligned_3d.tiff + twop_plane{P}_registration_params.npz)
+and HCR cellpose masks (HCR{R}_masks.tiff); the matcher itself adds no
+new prerequisites to the pipeline.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import tifffile
+from scipy import stats
+from scipy.ndimage import map_coordinates
+from scipy.spatial import cKDTree
+from skimage.measure import regionprops
+from sklearn.mixture import GaussianMixture
+from tqdm.auto import tqdm
+
+try:
+    from .meta import output_root, rprint  # Relative import (running as part of a package)
+except ImportError:
+    from meta import output_root, rprint  # Absolute import (running in Jupyter notebook)
+
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("MKL_NUM_THREADS", "1")
+os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+
+
+DEFAULTS = dict(
+    enabled=True,
+    # Algorithm mode:
+    #   '3d' = TRU-FACT 3D Soma-print (Schnitzer et al., bioRxiv 2026.04.28).
+    #          Runs the full 2D somaprint at each HCR z-slice within a per-cell
+    #          curved band (z_map(centroid) +/- z_band), then picks the
+    #          (slice, HCR cell) with the highest score per 2P cell. The paper
+    #          explicitly verifies precision/recall of this "best match in 3D"
+    #          is equivalent to the full pipeline with TPS manifold refit +
+    #          slab projection (those are for downstream visualisation).
+    #   '2d' = legacy single-plane mode: sample HCR at z_map then run 2D
+    #          somaprint once. Cheaper, but underestimates matches when the
+    #          cascade's z_map has local error > ~1 plane (see
+    #          figure_4_cortex/somaprint_tests/ analyses).
+    mode='3d',
+    z_band=2,                       # per-cell curved z-window for '3d' mode
+    m_2p=15,
+    m_hcr=30,
+    n_pairs=10,
+    lambda_scale=10.0,
+    radius_factor=3.0,
+    lr_threshold=0.05,
+    max_rounds=4,
+    terminate_pct=5.0,
+    n_pairs_r2=10,
+    min_confirmed_for_round2=5,
+    min_cells_for_gmm=30,
+)
+
+
+def get_params(full_manifest: dict) -> dict:
+    """Merge DEFAULTS with any params.somaprint overrides from the manifest."""
+    p = dict(DEFAULTS)
+    p.update(full_manifest.get('params', {}).get('somaprint', {}) or {})
+    return p
+
+
+def compute_plane_projected_hcr_sizes(full_manifest: dict,
+                                      session: dict,
+                                      hcr_round: str) -> dict:
+    """2D pixel count of each HCR mask at the warped 2P plane.
+
+    Loads the HCR cellpose mask volume, warps it through the 2P plane's
+    `z_map_local` (one z per (y,x) pixel — same warp somaprint uses
+    internally), then counts pixels per HCR label. The returned size is
+    the HCR cell's footprint at exactly where the 2P sheet sits — the
+    right denominator for plane-restricted IoU / containment with 2P.
+
+    Returns {hcr_label: int_pixel_count}. HCR cells that don't intersect
+    the warped 2P plane get an explicit 0 (rather than being omitted) so
+    downstream `df.HCR_mask_size < threshold` filters behave intuitively
+    on out-of-plane cells. Background (label 0) is excluded. Returns an
+    empty dict if any input file is missing.
+    """
+    plane = session['functional_plane'][0]
+    reg_dir = output_root(full_manifest) / '2P' / 'registered'
+    params_path = reg_dir / f'twop_plane{plane}_registration_params.npz'
+    hcr_masks_path = output_root(full_manifest) / 'HCR' / 'cellpose' / f'HCR{hcr_round}_masks.tiff'
+
+    for p in (params_path, hcr_masks_path):
+        if not Path(p).exists():
+            rprint(f"  [yellow][HCR_mask_size] missing input: {p}[/yellow]")
+            return {}
+
+    npz = np.load(str(params_path))
+    if 'z_map_local' not in npz.files:
+        rprint(f"  [yellow][HCR_mask_size] z_map_local missing from {params_path}[/yellow]")
+        return {}
+    z_map = npz['z_map_local']
+
+    hcr_3d = tifffile.imread(str(hcr_masks_path))
+    if hcr_3d.ndim != 3:
+        rprint(f"  [yellow][HCR_mask_size] unexpected HCR shape {hcr_3d.shape}[/yellow]")
+        return {}
+
+    ny, nx = z_map.shape
+    yy, xx = np.mgrid[0:ny, 0:nx]
+    coords = np.stack([z_map, yy, xx], axis=0)
+    hcr_2d = map_coordinates(hcr_3d, coords, order=0, mode='constant', cval=0)
+
+    # All HCR labels present anywhere in the 3D volume; default to 0 at-plane.
+    all_ids = np.unique(hcr_3d)
+    sizes = {int(i): 0 for i in all_ids if i > 0}
+    plane_ids, plane_counts = np.unique(hcr_2d, return_counts=True)
+    for i, c in zip(plane_ids, plane_counts):
+        if i > 0:
+            sizes[int(i)] = int(c)
+    return sizes
+
+
+def compute_full_hcr_sizes(full_manifest: dict, hcr_round: str) -> dict:
+    """Full 3D voxel count of each HCR mask in the reference volume.
+
+    Used as the fallback denominator in only_hcr mode, where there's no
+    2P plane to project against. Background (label 0) excluded.
+    """
+    hcr_masks_path = output_root(full_manifest) / 'HCR' / 'cellpose' / f'HCR{hcr_round}_masks.tiff'
+    if not hcr_masks_path.exists():
+        rprint(f"  [yellow][HCR_mask_size] missing input: {hcr_masks_path}[/yellow]")
+        return {}
+    hcr_3d = tifffile.imread(str(hcr_masks_path))
+    ids, counts = np.unique(hcr_3d, return_counts=True)
+    return {int(i): int(c) for i, c in zip(ids, counts) if i > 0}
+
+
+@dataclass
+class _SomaprintInputs:
+    twop_labels: np.ndarray
+    hcr_labels: np.ndarray
+    twop_centroids: np.ndarray
+    hcr_centroids: np.ndarray
+    twop_label_ids: np.ndarray
+    hcr_label_ids: np.ndarray
+    fov_span: int
+
+
+@dataclass
+class _RoundResult:
+    best_score: np.ndarray
+    second_score: np.ndarray
+    best_partner: np.ndarray
+    confident: dict
+
+
+def _extract_centroids(labels_2d: np.ndarray):
+    props = regionprops(labels_2d.astype(np.int32))
+    if not props:
+        return np.zeros((0, 2)), np.zeros(0, dtype=np.int64)
+    cents = np.array([[p.centroid[0], p.centroid[1]] for p in props])
+    ids = np.array([p.label for p in props], dtype=np.int64)
+    return cents, ids
+
+
+def _load_inputs(twop_3d_path: Path,
+                 params_path: Path,
+                 hcr_masks_path: Path) -> Optional[_SomaprintInputs]:
+    for p in (twop_3d_path, params_path, hcr_masks_path):
+        if not Path(p).exists():
+            rprint(f"  [yellow][somaprint] missing input: {p}[/yellow]")
+            return None
+
+    twop_3d = tifffile.imread(str(twop_3d_path))
+    if twop_3d.ndim != 3:
+        rprint(f"  [yellow][somaprint] unexpected 2P shape {twop_3d.shape}[/yellow]")
+        return None
+    # Each (y, x) holds at most one nonzero z by construction; max over z
+    # reproduces the 2D fully-warped labels in the HCR frame.
+    twop_labels = twop_3d.max(axis=0).astype(np.uint16)
+
+    npz = np.load(str(params_path))
+    if 'z_map_local' not in npz.files:
+        rprint(f"  [yellow][somaprint] z_map_local missing from {params_path}[/yellow]")
+        return None
+    z_map = npz['z_map_local']
+
+    hcr_3d = tifffile.imread(str(hcr_masks_path))
+    if hcr_3d.ndim != 3:
+        rprint(f"  [yellow][somaprint] unexpected HCR shape {hcr_3d.shape}[/yellow]")
+        return None
+
+    ny, nx = twop_labels.shape
+    if z_map.shape != (ny, nx):
+        rprint(f"  [yellow][somaprint] z_map shape {z_map.shape} != 2P labels {twop_labels.shape}[/yellow]")
+        return None
+
+    yy, xx = np.mgrid[0:ny, 0:nx]
+    coords = np.stack([z_map, yy, xx], axis=0)
+    hcr_labels = map_coordinates(hcr_3d, coords, order=0, mode='constant', cval=0).astype(np.uint16)
+
+    twop_cents, twop_ids = _extract_centroids(twop_labels)
+    hcr_cents, hcr_ids = _extract_centroids(hcr_labels)
+
+    return _SomaprintInputs(
+        twop_labels=twop_labels,
+        hcr_labels=hcr_labels,
+        twop_centroids=twop_cents,
+        hcr_centroids=hcr_cents,
+        twop_label_ids=twop_ids,
+        hcr_label_ids=hcr_ids,
+        fov_span=int(max(twop_labels.shape)),
+    )
+
+
+@dataclass
+class _SomaprintInputs3D:
+    """Inputs for 3D mode: full HCR volume + per-cell z_warp from z_map."""
+    twop_labels: np.ndarray
+    twop_centroids: np.ndarray
+    twop_label_ids: np.ndarray
+    fov_span: int
+    z_warp_per_cell: np.ndarray   # z_map sampled at each 2P centroid (n_2p,)
+    hcr_3d: np.ndarray            # full HCR label volume (Z, Y, X)
+
+
+def _load_inputs_3d(twop_3d_path: Path,
+                    params_path: Path,
+                    hcr_masks_path: Path) -> Optional[_SomaprintInputs3D]:
+    """Like _load_inputs but keeps HCR 3D (no per-pixel z_map sampling).
+
+    The 2D loader pre-samples HCR at z_map(y, x) and returns a single 2D
+    HCR slice. 3D mode needs the full HCR volume so the per-z somaprint
+    scan can look at slices on either side of z_map. We also pre-compute
+    each 2P cell's z_warp = z_map(centroid) so the per-z scan can quickly
+    select which cells are in-band at a given HCR slice.
+    """
+    for p in (twop_3d_path, params_path, hcr_masks_path):
+        if not Path(p).exists():
+            rprint(f"  [yellow][somaprint] missing input: {p}[/yellow]")
+            return None
+
+    twop_3d = tifffile.imread(str(twop_3d_path))
+    if twop_3d.ndim != 3:
+        rprint(f"  [yellow][somaprint] unexpected 2P shape {twop_3d.shape}[/yellow]")
+        return None
+    twop_labels = twop_3d.max(axis=0).astype(np.uint16)
+
+    npz = np.load(str(params_path))
+    if 'z_map_local' not in npz.files:
+        rprint(f"  [yellow][somaprint] z_map_local missing from {params_path}[/yellow]")
+        return None
+    z_map = npz['z_map_local']
+
+    hcr_3d = tifffile.imread(str(hcr_masks_path))
+    if hcr_3d.ndim != 3:
+        rprint(f"  [yellow][somaprint] unexpected HCR shape {hcr_3d.shape}[/yellow]")
+        return None
+
+    ny, nx = twop_labels.shape
+    if z_map.shape != (ny, nx):
+        rprint(f"  [yellow][somaprint] z_map shape {z_map.shape} != 2P labels {twop_labels.shape}[/yellow]")
+        return None
+
+    twop_cents, twop_ids = _extract_centroids(twop_labels)
+    if len(twop_cents) > 0:
+        cy = np.clip(np.round(twop_cents[:, 0]).astype(int), 0, ny - 1)
+        cx = np.clip(np.round(twop_cents[:, 1]).astype(int), 0, nx - 1)
+        z_warp = z_map[cy, cx].astype(np.float32)
+    else:
+        z_warp = np.zeros(0, dtype=np.float32)
+
+    return _SomaprintInputs3D(
+        twop_labels=twop_labels,
+        twop_centroids=twop_cents,
+        twop_label_ids=twop_ids,
+        fov_span=int(max(twop_labels.shape)),
+        z_warp_per_cell=z_warp,
+        hcr_3d=hcr_3d,
+    )
+
+
+def _build_neighbor_vectors(centroids: np.ndarray, m: int):
+    n = len(centroids)
+    if n == 0:
+        return np.zeros((0, m, 2)), np.zeros((0, m), dtype=np.int64)
+    m_eff = max(1, min(m, n - 1))
+    tree = cKDTree(centroids)
+    _, nbr_idx = tree.query(centroids, k=m_eff + 1)
+    if nbr_idx.ndim == 1:
+        nbr_idx = nbr_idx[:, None]
+    nbr_idx = nbr_idx[:, 1:]
+    vecs = centroids[nbr_idx] - centroids[:, None, :]
+    if m_eff < m:
+        pad_v = np.full((n, m - m_eff, 2), np.nan)
+        pad_i = np.full((n, m - m_eff), -1, dtype=np.int64)
+        vecs = np.concatenate([vecs, pad_v], axis=1)
+        nbr_idx = np.concatenate([nbr_idx, pad_i], axis=1)
+    return vecs, nbr_idx
+
+
+def _greedy_match_fast(cost: np.ndarray, n: int) -> float:
+    c = cost.copy()
+    n_actual = min(n, c.shape[0], c.shape[1])
+    if n_actual == 0:
+        return np.inf
+    delta_sum = 0.0
+    for _ in range(n_actual):
+        ia, ib = np.unravel_index(np.argmin(c), c.shape)
+        v = c[ia, ib]
+        if not np.isfinite(v):
+            break
+        delta_sum += v
+        c[ia, :] = np.inf
+        c[:, ib] = np.inf
+    return delta_sum / n_actual
+
+
+def _gmm_density(scores: np.ndarray, gmm: GaussianMixture) -> np.ndarray:
+    means = gmm.means_.ravel()
+    stds = np.sqrt(gmm.covariances_.ravel())
+    ws = gmm.weights_
+    return (ws[0] * stats.norm.pdf(scores, means[0], stds[0])
+            + ws[1] * stats.norm.pdf(scores, means[1], stds[1]))
+
+
+def _curate_with_gmm(best_score: np.ndarray,
+                     second_score: np.ndarray,
+                     best_partner: np.ndarray,
+                     valid_mask: np.ndarray,
+                     lr_threshold: float,
+                     min_cells_for_gmm: int) -> dict:
+    n_valid = int(valid_mask.sum())
+    if n_valid < min_cells_for_gmm:
+        return {}
+
+    best_v = best_score[valid_mask]
+    second_v = second_score[valid_mask]
+    mu_2nd = float(np.mean(second_v))
+    sd_2nd = float(np.std(second_v))
+    if sd_2nd <= 0:
+        return {}
+
+    try:
+        gmm = GaussianMixture(n_components=2, random_state=0).fit(best_v.reshape(-1, 1))
+    except Exception:  # noqa: BLE001
+        threshold = float(np.percentile(best_v, 75))
+        return {int(vi): int(best_partner[vi])
+                for vi in np.where(valid_mask)[0]
+                if best_score[vi] >= threshold and best_partner[vi] >= 0}
+
+    p_inc = stats.norm.pdf(best_score, mu_2nd, sd_2nd)
+    p_gmm = _gmm_density(best_score, gmm)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        ratio = p_inc / p_gmm
+        lr = np.where(np.isfinite(ratio), ratio, np.inf)
+
+    return {int(vi): int(best_partner[vi])
+            for vi in np.where(valid_mask)[0]
+            if lr[vi] < lr_threshold and best_partner[vi] >= 0}
+
+
+def _score_round1(inputs: _SomaprintInputs, params: dict, plane: int) -> _RoundResult:
+    fov_span = inputs.fov_span
+    lam = fov_span / params['lambda_scale']
+    radius = params['radius_factor'] * lam
+    n_pairs = params['n_pairs']
+
+    twop_cents = inputs.twop_centroids
+    hcr_cents = inputs.hcr_centroids
+    n_2p = len(twop_cents)
+
+    if n_2p == 0 or len(hcr_cents) == 0:
+        return _RoundResult(
+            best_score=np.full(n_2p, np.nan),
+            second_score=np.full(n_2p, np.nan),
+            best_partner=np.full(n_2p, -1, dtype=np.int64),
+            confident={},
+        )
+
+    twop_vecs, _ = _build_neighbor_vectors(twop_cents, params['m_2p'])
+    hcr_vecs, _ = _build_neighbor_vectors(hcr_cents, params['m_hcr'])
+    hcr_tree = cKDTree(hcr_cents)
+
+    best_score = np.full(n_2p, np.nan)
+    second_score = np.full(n_2p, np.nan)
+    best_partner = np.full(n_2p, -1, dtype=np.int64)
+
+    desc = f"  [somaprint] plane {plane} scoring"
+    for i_a in tqdm(range(n_2p), desc=desc, leave=False):
+        cand = hcr_tree.query_ball_point(twop_cents[i_a], r=radius)
+        if len(cand) < 2:
+            continue
+        vecs_a = twop_vecs[i_a]
+        vecs_b_batch = hcr_vecs[cand]
+        diff = vecs_a[None, :, None, :] - vecs_b_batch[:, None, :, :]
+        cost_batch = np.linalg.norm(diff, axis=-1)
+        cost_batch = np.where(np.isnan(cost_batch), np.inf, cost_batch)
+        dx_arr = np.linalg.norm(hcr_cents[cand] - twop_cents[i_a], axis=1)
+        pen_arr = np.exp(-(dx_arr / lam) ** 2)
+
+        scores = np.empty(len(cand))
+        for k, c in enumerate(cost_batch):
+            delta_bar = _greedy_match_fast(c, n_pairs)
+            scores[k] = (100.0 / (1.0 + delta_bar)) * pen_arr[k]
+
+        order = np.argsort(scores)[::-1]
+        best_score[i_a] = scores[order[0]]
+        second_score[i_a] = scores[order[1]] if len(order) > 1 else np.nan
+        best_partner[i_a] = cand[order[0]]
+
+    valid_mask = ~np.isnan(best_score) & ~np.isnan(second_score)
+    confident = _curate_with_gmm(
+        best_score, second_score, best_partner, valid_mask,
+        lr_threshold=params['lr_threshold'],
+        min_cells_for_gmm=params['min_cells_for_gmm'],
+    )
+    return _RoundResult(best_score=best_score, second_score=second_score,
+                       best_partner=best_partner, confident=confident)
+
+
+def _score_round_identity(inputs: _SomaprintInputs,
+                          params: dict,
+                          current_matches: dict):
+    fov_span = inputs.fov_span
+    lam = fov_span / params['lambda_scale']
+    radius = params['radius_factor'] * lam
+    n_pairs_r2 = params['n_pairs_r2']
+    min_conf = params['min_confirmed_for_round2']
+
+    twop_cents = inputs.twop_centroids
+    hcr_cents = inputs.hcr_centroids
+    n_2p = len(twop_cents)
+
+    confirmed_2p_idxs = list(current_matches.keys())
+    confirmed_2p_array = np.array(confirmed_2p_idxs, dtype=np.int64)
+    confirmed_hcr_array = np.array([current_matches[i] for i in confirmed_2p_idxs], dtype=np.int64)
+
+    blank = (np.full(n_2p, np.nan),
+             np.full(n_2p, np.nan),
+             np.full(n_2p, -1, dtype=np.int64),
+             np.zeros(n_2p, dtype=bool))
+    if len(confirmed_2p_array) < min_conf:
+        return blank
+
+    confirmed_tree = cKDTree(twop_cents[confirmed_2p_array])
+    hcr_tree = cKDTree(hcr_cents)
+
+    best_score = np.full(n_2p, np.nan)
+    second_score = np.full(n_2p, np.nan)
+    best_partner = np.full(n_2p, -1, dtype=np.int64)
+    valid = np.zeros(n_2p, dtype=bool)
+    n_query = n_pairs_r2 + 2
+
+    for i_a in range(n_2p):
+        k_query = min(n_query, len(confirmed_2p_array))
+        d_to_conf, idxs_in_conf = confirmed_tree.query(twop_cents[i_a], k=k_query)
+        d_to_conf = np.atleast_1d(d_to_conf)
+        idxs_in_conf = np.atleast_1d(idxs_in_conf)
+        idxs_in_conf = idxs_in_conf[d_to_conf > 1e-6][:n_pairs_r2]
+        if len(idxs_in_conf) < 5:
+            continue
+
+        confirmed_2p_neigh = confirmed_2p_array[idxs_in_conf]
+        confirmed_hcr_neigh = confirmed_hcr_array[idxs_in_conf]
+        vecs_a = twop_cents[confirmed_2p_neigh] - twop_cents[i_a]
+
+        cands = hcr_tree.query_ball_point(twop_cents[i_a], r=radius)
+        if len(cands) < 2:
+            continue
+        cands_arr = np.array(cands)
+
+        b_centroids = hcr_cents[cands_arr][:, None, :]
+        b_neigh_centroids = hcr_cents[confirmed_hcr_neigh][None, :, :]
+        vecs_b_batch = b_neigh_centroids - b_centroids
+
+        diff = vecs_a[None, :, :] - vecs_b_batch
+        dbar = np.linalg.norm(diff, axis=2).mean(axis=1)
+        dx_arr = np.linalg.norm(hcr_cents[cands_arr] - twop_cents[i_a], axis=1)
+        pen_arr = np.exp(-(dx_arr / lam) ** 2)
+        scores = (100.0 / (1.0 + dbar)) * pen_arr
+
+        order = np.argsort(scores)[::-1]
+        best_score[i_a] = scores[order[0]]
+        second_score[i_a] = scores[order[1]] if len(order) > 1 else np.nan
+        best_partner[i_a] = cands_arr[order[0]]
+        valid[i_a] = True
+
+    return best_score, second_score, best_partner, valid
+
+
+def _iterate_rounds(inputs: _SomaprintInputs,
+                    params: dict,
+                    round1: _RoundResult) -> _RoundResult:
+    """Run identity-paired refinement; return the final-round result."""
+    current = round1
+    for _ in range(params['max_rounds']):
+        if len(current.confident) < params['min_confirmed_for_round2']:
+            break
+        best, second, partner, valid = _score_round_identity(inputs, params, current.confident)
+        n_valid = int(valid.sum())
+        if n_valid < params['min_cells_for_gmm']:
+            break
+        new_matches = _curate_with_gmm(
+            best, second, partner, valid,
+            lr_threshold=params['lr_threshold'],
+            min_cells_for_gmm=params['min_cells_for_gmm'],
+        )
+        prev_n = len(current.confident)
+        new_n = len(new_matches)
+        delta_pct = 100.0 * abs(new_n - prev_n) / max(prev_n, 1)
+        current = _RoundResult(best_score=best, second_score=second,
+                              best_partner=partner, confident=new_matches)
+        if delta_pct < params['terminate_pct']:
+            break
+    return current
+
+
+def _run_3d_match(inputs: _SomaprintInputs3D, params: dict, plane: int) -> dict:
+    """Per-slice full 2D somaprint + per-cell max-score aggregation across z.
+
+    Implements the TRU-FACT 3D Soma-print algorithm:
+      1. For each HCR z-slice in the outer range
+         [floor(z_warp.min()) - z_band, ceil(z_warp.max()) + z_band], run
+         the full 2D somaprint (round 1 + identity rounds + GMM curation)
+         on the 2P cells whose own z_warp is within z_band of z (curved
+         per-cell band that follows the folded sheet).
+      2. For each 2P cell, pick the (z, HCR cell) with the highest final-
+         round somaprint score across all slices it was scored at.
+
+    The paper's downstream TPS-manifold refit + slab projection are skipped
+    because their purpose is to produce a coherent 2D HCR reference image
+    for visualisation; the paper explicitly verifies match precision/recall
+    are unchanged when you stop at the per-cell argmax-z stage.
+
+    Returns a dict of n_2p-length arrays:
+      score, second, hcr_label, z, confident.
+    """
+    z_band = int(params['z_band'])
+    n_2p = len(inputs.twop_centroids)
+    n_z_total = inputs.hcr_3d.shape[0]
+
+    top1_score     = np.full(n_2p, -np.inf, dtype=np.float64)
+    top1_second    = np.full(n_2p, np.nan,  dtype=np.float64)
+    top1_hcr_label = np.zeros(n_2p,         dtype=np.int64)
+    top1_z         = np.full(n_2p, -1,      dtype=np.int32)
+    top1_confident = np.zeros(n_2p,         dtype=bool)
+
+    if n_2p == 0:
+        return dict(score=top1_score, second=top1_second,
+                    hcr_label=top1_hcr_label, z=top1_z, confident=top1_confident)
+
+    z_warp = inputs.z_warp_per_cell
+    z_lo = max(0, int(np.floor(z_warp.min())) - z_band)
+    z_hi = min(n_z_total, int(np.ceil(z_warp.max())) + z_band + 1)
+
+    desc = f"  [somaprint] plane {plane} 3D scan (z={z_lo}..{z_hi - 1})"
+    for z in tqdm(range(z_lo, z_hi), desc=desc, leave=False):
+        in_band = np.abs(z - z_warp) <= z_band
+        n_in = int(in_band.sum())
+        if n_in < params['min_cells_for_gmm']:
+            continue   # not enough cells for the GMM curation to be stable
+        hcr_2d = inputs.hcr_3d[z].astype(np.uint16)
+        if hcr_2d.max() == 0:
+            continue
+        hcr_cents, hcr_ids = _extract_centroids(hcr_2d)
+        if len(hcr_cents) < 2:
+            continue
+
+        in_band_idx = np.where(in_band)[0]
+        slice_inputs = _SomaprintInputs(
+            twop_labels=inputs.twop_labels,
+            hcr_labels=hcr_2d,
+            twop_centroids=inputs.twop_centroids[in_band],
+            hcr_centroids=hcr_cents,
+            twop_label_ids=inputs.twop_label_ids[in_band],
+            hcr_label_ids=hcr_ids,
+            fov_span=inputs.fov_span,
+        )
+        round1 = _score_round1(slice_inputs, params, plane)
+        final = _iterate_rounds(slice_inputs, params, round1)
+
+        # Aggregate winners. final.* arrays are indexed against the in-band
+        # subset; map back to full-array indices via in_band_idx.
+        for j, i_a in enumerate(in_band_idx):
+            s = final.best_score[j]
+            bp = int(final.best_partner[j])
+            if not np.isfinite(s) or bp < 0:
+                continue
+            if s > top1_score[i_a]:
+                top1_score[i_a]     = s
+                top1_second[i_a]    = final.second_score[j]
+                top1_hcr_label[i_a] = int(hcr_ids[bp])
+                top1_z[i_a]         = z
+                top1_confident[i_a] = j in final.confident
+
+    return dict(score=top1_score, second=top1_second,
+                hcr_label=top1_hcr_label, z=top1_z, confident=top1_confident)
+
+
+def run_for_plane(full_manifest: dict, session: dict, hcr_round: str) -> dict:
+    """Match 2P cells to HCR cells via somaprint for a single plane.
+
+    Inputs are sourced from the pipeline's existing per-plane registration
+    outputs and HCR cellpose masks; this function adds no new prerequisites.
+
+    Returns a per-2P-label dict
+        {twop_label: (somaprint_hcr_label, best_score, second_score, confident)}
+    covering every 2P cell with a candidate; cells with no candidate are
+    omitted. `confident` is True for picks that passed the GMM/likelihood
+    curation, False for unconfident best-picks (still useful diagnostically
+    via the score columns).
+
+    Returns an empty dict if inputs are unavailable, no cells were detected,
+    or somaprint is disabled in the manifest.
+    """
+    params = get_params(full_manifest)
+    if not params.get('enabled', True):
+        return {}
+
+    plane = session['functional_plane'][0]
+    reg_dir = output_root(full_manifest) / '2P' / 'registered'
+    twop_3d_path = reg_dir / f'twop_plane{plane}_aligned_3d.tiff'
+    params_path = reg_dir / f'twop_plane{plane}_registration_params.npz'
+    hcr_masks_path = output_root(full_manifest) / 'HCR' / 'cellpose' / f'HCR{hcr_round}_masks.tiff'
+
+    t0 = time.time()
+    mode = str(params.get('mode', '3d')).lower()
+
+    if mode == '3d':
+        inputs3d = _load_inputs_3d(twop_3d_path, params_path, hcr_masks_path)
+        if inputs3d is None:
+            return {}
+        n_2p = len(inputs3d.twop_centroids)
+        n_z  = inputs3d.hcr_3d.shape[0]
+        if n_2p == 0:
+            rprint(f"  [yellow][somaprint] plane {plane}: no 2P cells; skipping[/yellow]")
+            return {}
+        rprint(f"  [somaprint] plane {plane}: {n_2p} 2P cells, 3D mode "
+               f"(z_band=+/-{params['z_band']}, HCR z={n_z}), scoring...")
+        result = _run_3d_match(inputs3d, params, plane)
+
+        out = {}
+        for i_a in range(n_2p):
+            hcr_lbl = int(result['hcr_label'][i_a])
+            if hcr_lbl == 0:
+                continue
+            twop_lbl = int(inputs3d.twop_label_ids[i_a])
+            bs = float(result['score'][i_a]) if np.isfinite(result['score'][i_a]) else float('nan')
+            ss = float(result['second'][i_a]) if np.isfinite(result['second'][i_a]) else float('nan')
+            confident = bool(result['confident'][i_a])
+            out[twop_lbl] = (hcr_lbl, bs, ss, confident)
+        n_conf = sum(1 for v in out.values() if v[3])
+        rprint(f"  [somaprint] plane {plane}: {n_conf}/{n_2p} cells confidently matched "
+               f"(3D mode, {time.time() - t0:.1f}s)")
+        return out
+
+    # mode == '2d' (legacy single-plane sample at z_map)
+    inputs = _load_inputs(twop_3d_path, params_path, hcr_masks_path)
+    if inputs is None:
+        return {}
+    n_2p, n_hcr = len(inputs.twop_centroids), len(inputs.hcr_centroids)
+    if n_2p == 0 or n_hcr == 0:
+        rprint(f"  [yellow][somaprint] plane {plane}: empty masks ({n_2p} 2P / {n_hcr} HCR); skipping[/yellow]")
+        return {}
+
+    rprint(f"  [somaprint] plane {plane}: {n_2p} 2P + {n_hcr} HCR cells, 2D mode, scoring...")
+    round1 = _score_round1(inputs, params, plane)
+    final = _iterate_rounds(inputs, params, round1)
+
+    # Build per-2P-label output. Index space → label space happens here so
+    # downstream code only sees cellpose label IDs.
+    out = {}
+    for i_a in range(len(inputs.twop_label_ids)):
+        bp = int(final.best_partner[i_a])
+        if bp < 0:
+            continue
+        twop_lbl = int(inputs.twop_label_ids[i_a])
+        hcr_lbl = int(inputs.hcr_label_ids[bp])
+        bs = float(final.best_score[i_a]) if np.isfinite(final.best_score[i_a]) else float('nan')
+        ss = float(final.second_score[i_a]) if np.isfinite(final.second_score[i_a]) else float('nan')
+        confident = i_a in final.confident
+        out[twop_lbl] = (hcr_lbl, bs, ss, confident)
+
+    n_conf = sum(1 for v in out.values() if v[3])
+    rprint(f"  [somaprint] plane {plane}: {n_conf}/{n_2p} cells confidently matched "
+           f"(2D mode, {time.time() - t0:.1f}s)")
+    return out

--- a/src/tiling.py
+++ b/src/tiling.py
@@ -10,7 +10,7 @@ from sbxreader import sbx_get_metadata, sbx_memmap
 from tifffile import imread as tif_imread
 from tifffile import imwrite as tif_imwrite
 from .registrations import verify_rounds
-from .meta import check_rotation, get_automation_config, get_rotation_config, get_stitching_config, parse_json
+from .meta import check_rotation, get_automation_config, get_rotation_config, get_stitching_config, parse_json, output_root
 from .auto_stitching import auto_stitch_tiles, StitchingError
 from skimage.transform import rotate
 
@@ -84,7 +84,7 @@ def unwarp_tiles(full_manifest: dict, session: dict):
     num_tiles = len(session['anatomical_hires_green_runs'])
     tiles_to_unwarp = []
     for i in range(1, 1 + num_tiles):
-        unwarp_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / '2P' / 'tile' / 'unwarped' / f'stack_unwarped_C12_{i:03}.tiff'
+        unwarp_path = output_root(full_manifest) / '2P' / 'tile' / 'unwarped' / f'stack_unwarped_C12_{i:03}.tiff'
         if not os.path.exists(unwarp_path):
             tiles_to_unwarp.append(i)
 
@@ -94,8 +94,8 @@ def unwarp_tiles(full_manifest: dict, session: dict):
 
     print(f'Unwarping {len(tiles_to_unwarp)}/{num_tiles} tiles for session {session["date"]}')
     for i in tiles_to_unwarp:
-        warp_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / '2P' / 'tile' / 'warped' / f'stack_warped_C12_{i:03}.tiff'
-        unwarp_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / '2P' / 'tile' / 'unwarped' / f'stack_unwarped_C12_{i:03}.tiff'
+        warp_path = output_root(full_manifest) / '2P' / 'tile' / 'warped' / f'stack_warped_C12_{i:03}.tiff'
+        unwarp_path = output_root(full_manifest) / '2P' / 'tile' / 'unwarped' / f'stack_unwarped_C12_{i:03}.tiff'
         unwarp_path.parent.mkdir(exist_ok=True, parents=True)
         unwarp_tile(warp_path,
                     session['unwarp_config'],
@@ -148,7 +148,7 @@ def process_session_sbx(full_manifest: dict , session:dict):
         return
 
     base_2P = Path(manifest['base_path']) / manifest['mouse_name'] / '2P'
-    save_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / '2P' / 'tile' / 'warped'
+    save_path = output_root(full_manifest) / '2P' / 'tile' / 'warped'
     mouse_name = manifest['mouse_name']
     date = session['date']
 
@@ -217,10 +217,10 @@ def stitch_tiles_and_rotate(full_manifest: dict, session: dict):
     # Full stitched volume (Z,C,Y,X) — plane-neutral name so subsequent
     # functional planes short-circuit auto_stitch_tiles instead of re-writing
     # the identical stack under a different filename.
-    stitched_file  = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / '2P' / 'tile' / 'stitched' / 'hires_stitched.tiff'
-    tile_base_path = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / '2P' / 'tile'
+    stitched_file  = output_root(full_manifest) / '2P' / 'tile' / 'stitched' / 'hires_stitched.tiff'
+    tile_base_path = output_root(full_manifest) / '2P' / 'tile'
     unwarped_path = tile_base_path / 'unwarped'
-    save_path_registered = Path(manifest['base_path']) / manifest['mouse_name'] / 'OUTPUT' / '2P' / 'registered'
+    save_path_registered = output_root(full_manifest) / '2P' / 'registered'
     save_path_registered.mkdir(exist_ok=True, parents=True)
     stitched_file.parent.mkdir(exist_ok=True, parents=True)
 

--- a/src/tiling.py
+++ b/src/tiling.py
@@ -5,13 +5,17 @@ from pathlib import Path
 import cv2
 import hjson
 import numpy as np
-from rich import print as rprint
 from sbxreader import sbx_get_metadata, sbx_memmap
 from tifffile import imread as tif_imread
 from tifffile import imwrite as tif_imwrite
-from .registrations import verify_rounds
-from .meta import check_rotation, get_automation_config, get_rotation_config, get_stitching_config, parse_json, output_root
-from .auto_stitching import auto_stitch_tiles, StitchingError
+try:
+    from .registrations import verify_rounds  # Relative import (running as part of a package)
+    from .meta import check_rotation, get_automation_config, get_rotation_config, get_stitching_config, parse_json, output_root, rprint
+    from .auto_stitching import auto_stitch_tiles, StitchingError
+except ImportError:
+    from registrations import verify_rounds  # Absolute import (running in Jupyter notebook)
+    from meta import check_rotation, get_automation_config, get_rotation_config, get_stitching_config, parse_json, output_root, rprint
+    from auto_stitching import auto_stitch_tiles, StitchingError
 from skimage.transform import rotate
 
 def update_map(map_x, map_y, poly_vals, src):
@@ -103,7 +107,9 @@ def unwarp_tiles(full_manifest: dict, session: dict):
                     unwarp_path)
         
 
-def _hires_sbx_channel_mean(sbx_path: Path, channel: int, register: bool) -> np.ndarray:
+def _hires_sbx_channel_mean(sbx_path: Path, channel: int, register: bool,
+                            subsample: int = 1, tmats_per_z=None,
+                            return_tmats: bool = False):
     '''
     Return the time-mean of one channel of an SBX file as a (Z, Y, X) array.
 
@@ -112,6 +118,16 @@ def _hires_sbx_channel_mean(sbx_path: Path, channel: int, register: bool) -> np.
     ported from register_sbx_general.py). When register=False, a plain
     time-mean is returned (original pipeline behavior).
 
+    Optimizations:
+      - The (T, Z, Y, X) chunk for the chosen channel is read in a single
+        contiguous pass instead of slicing per-Z (1 network read instead of n_planes).
+      - subsample > 1 keeps every Nth frame (after the leading skip) for both
+        tmat estimation and averaging — ~Nx fewer StackReg fits at the cost of
+        a slightly noisier mean.
+      - If tmats_per_z is provided (list of (T', 3, 3) arrays from a same-file
+        green pass), tmats are reused instead of re-estimated.
+      - return_tmats returns ((Z, Y, X), tmats_per_z) for downstream reuse.
+
     Handles both single-plane and optotune multi-plane SBX (shape (T, Z, C, Y, X)).
     '''
     dat = sbx_memmap(sbx_path)  # memmap (T, Z, C, Y, X)
@@ -119,7 +135,8 @@ def _hires_sbx_channel_mean(sbx_path: Path, channel: int, register: bool) -> np.
     ch = channel if channel >= 0 else dat.shape[2] + channel
 
     if not register:
-        return np.array(dat[:, :, ch]).mean(0)  # (Z, Y, X)
+        out = np.array(dat[:, :, ch]).mean(0)  # (Z, Y, X)
+        return (out, None) if return_tmats else out
 
     from pystackreg import StackReg
 
@@ -127,14 +144,26 @@ def _hires_sbx_channel_mean(sbx_path: Path, channel: int, register: bool) -> np.
     # 2 leading cycles for multiplane (each memmap T index is one full cycle).
     skip = 3 if n_planes == 1 else 2
 
+    # Single contiguous read of (T', Z, Y, X) for this channel.
+    stack = np.array(dat[skip::max(int(subsample), 1), :, ch, :, :])
+
     sr = StackReg(StackReg.RIGID_BODY)
     plane_means = []
+    out_tmats = [] if (return_tmats or tmats_per_z is not None) else None
     for z in range(n_planes):
-        plane = np.array(dat[skip:, z, ch, :, :])  # (T, Y, X)
-        tmats = sr.register_stack(plane[:, 50:-50, 50:-50], reference='mean', verbose=False)
+        plane = stack[:, z]  # (T', Y, X)
+        if tmats_per_z is not None:
+            tmats = tmats_per_z[z]
+        else:
+            tmats = sr.register_stack(plane[:, 50:-50, 50:-50], reference='mean', verbose=False)
         registered = sr.transform_stack(plane, tmats=tmats)
         plane_means.append(registered.mean(0))
-    return np.stack(plane_means, axis=0)  # (Z, Y, X)
+        if out_tmats is not None and tmats_per_z is None:
+            out_tmats.append(tmats)
+    out = np.stack(plane_means, axis=0)  # (Z, Y, X)
+    if return_tmats:
+        return out, (out_tmats if tmats_per_z is None else tmats_per_z)
+    return out
 
 
 def process_session_sbx(full_manifest: dict , session:dict):
@@ -159,6 +188,10 @@ def process_session_sbx(full_manifest: dict , session:dict):
     input_format = session.get('input_format', 'sbx')
     params = full_manifest.get('params', {})
     register_hires = params.get('hires_sbx_registration', True) and input_format != 'tiff'
+    # Frame subsampling for StackReg estimation+averaging. Default 4 gives ~4x
+    # speedup with negligible quality loss on anatomical hi-res tiles. Set to 1
+    # in the manifest to recover the original use-every-frame behavior.
+    hires_subsample = max(int(params.get('hires_sbx_subsample', 4)), 1)
 
     # Support variable number of tiles (not just 3)
     num_tiles = len(session['anatomical_hires_green_runs'])
@@ -190,8 +223,26 @@ def process_session_sbx(full_manifest: dict , session:dict):
         red_sbx = base_2P / f'{mouse_name}_{date}_{red_run}' / f'{mouse_name}_{date}_{red_run}.sbx'
 
         print(f'  Tile {j+1}: {green_sbx.name} + {red_sbx.name}')
-        green_stack = np.expand_dims(_hires_sbx_channel_mean(green_sbx, 0, register_hires), 1)
-        red_stack = np.expand_dims(_hires_sbx_channel_mean(red_sbx, -1, register_hires), 1)
+        # If green and red come from the same SBX file (typical: both channels
+        # acquired simultaneously), motion is identical — estimate tmats on green
+        # and reuse for red. Halves the StackReg work per tile.
+        same_file = register_hires and green_sbx.resolve() == red_sbx.resolve()
+        if same_file:
+            green_mean, tmats_per_z = _hires_sbx_channel_mean(
+                green_sbx, 0, True, subsample=hires_subsample, return_tmats=True
+            )
+            red_mean = _hires_sbx_channel_mean(
+                red_sbx, -1, True, subsample=hires_subsample, tmats_per_z=tmats_per_z
+            )
+        else:
+            green_mean = _hires_sbx_channel_mean(
+                green_sbx, 0, register_hires, subsample=hires_subsample
+            )
+            red_mean = _hires_sbx_channel_mean(
+                red_sbx, -1, register_hires, subsample=hires_subsample
+            )
+        green_stack = np.expand_dims(green_mean, 1)
+        red_stack = np.expand_dims(red_mean, 1)
         combined_stack = np.concatenate([green_stack,red_stack],1)
 
         tif_imwrite(save_filename, combined_stack.astype(np.float32),
@@ -272,6 +323,7 @@ def stitch_tiles_and_rotate(full_manifest: dict, session: dict):
         noise_floor = stitch_params.get('noise_floor', 15.0)
         min_signal_frac = stitch_params.get('min_signal_frac', 0.01)
         upsample_factor = stitch_params.get('upsample_factor', 10)
+        stitch_channel = stitch_params.get('stitch_channel', 0)
 
         try:
             # Run automated stitching
@@ -283,7 +335,8 @@ def stitch_tiles_and_rotate(full_manifest: dict, session: dict):
                 overlap_fraction=overlap_fraction,
                 noise_floor=noise_floor,
                 min_signal_frac=min_signal_frac,
-                upsample_factor=upsample_factor
+                upsample_factor=upsample_factor,
+                stitch_channel=stitch_channel,
             )
             rprint(f"[bold green]✓ Automated stitching successful![/bold green]")
 


### PR DESCRIPTION
## Summary
- **Cellpose 4 (cellpose-SAM) port** for HCR + 2P segmentation, with per-slice progress, quieter single-round logging, and `z_axis=0` fix for 3D eval. New plausibility filter drops obviously-bad cp4 outputs before downstream matching.
- **Somaprint matcher** (new `src/somaprint.py`) Runs alongside the IoU matcher and writes parallel `twoP_somaprint_*` columns to the merged feature table. Validated against IoU on JS078 (98-99% concordance at IoU>=0).
- **2P->HCR registration knobs surfaced in manifests** — `cascade_stages`, `erosion`, `erosion_hcr`, `z_range_global`, `xy_max_global`, `hull_margin`, `flip_z` in demo + param_example hjsons, with self-documenting comments and tuning guidance. Lower-tier params still fall through to defaults.
- **Per-stage cascade snapshots** from `twop_to_hcr_registration` + per-plane match summary printed at end of run.
- TIFF resolution helpers, `output_root` for `OUTPUT_dir_suffix` support, and minor cleanups across `tiling`, `auto_stitching`, `analysis_utils`, `automation`.
- New `ezfish_all_cp4_environment_v2.yml` conda env for this work