### PR TITLE
Tighten the README 

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -2,139 +2,120 @@
 
 Align two-photon functional imaging to multi-round in-situ molecular imaging, cell by cell.
 
-EASI-PASS takes a **mean image** from a functional recording and one or more **EASI-FISH
-confocal volumes**, segments cells in both, registers them onto each other, matches cells
-across modalities, and writes a single per-cell table joining functional identity to
-molecular readout. It also runs without any functional data, to register and match cells
-across successive FISH rounds alone.
+EASI-PASS takes a mean image from a functional recording and one or more EASI-FISH confocal
+volumes, segments cells in both, registers them onto each other, matches cells across
+modalities, and writes a per-cell table joining functional identity to molecular readout. It
+also runs without any functional data, registering and matching cells across successive FISH
+rounds alone.
 
-It is a registration-and-matching pipeline. It does not process raw functional recordings,
-compute ΔF/F, or stitch image tiles — those happen upstream, and EASI-PASS takes their
-output as input.
+It does not process raw recordings, compute ΔF/F, or stitch image tiles. Those happen
+upstream, and EASI-PASS takes their output as input.
 
 ## What it needs
 
 | Input | Format |
 |---|---|
-| Functional field of view | One 2D **mean image** per plane, TIFF |
-| Molecular rounds | One multi-channel **3D volume** per FISH round, TIFF |
-| *(optional)* Hi-res structural image | A single stitched 2D TIFF per plane, used as an alignment bridge |
-| A few seed landmarks | Placed once in [BigWarp](https://imagej.net/plugins/bigwarp), between one functional plane and the reference FISH volume. Only needed for cross-modal runs — FISH-only runs need none, and **the demo ships its landmarks, so you never open BigWarp to run it** |
+| Functional field of view | One 2D mean image per plane, TIFF |
+| Molecular rounds | One multi-channel 3D volume per FISH round, TIFF |
+| Hi-res structural image *(optional)* | One stitched 2D TIFF per plane, used as an alignment bridge |
+| A few seed landmarks | Placed once in [BigWarp](https://imagej.net/plugins/bigwarp), between one functional plane and the reference FISH volume. Not needed for FISH-only runs, and the demo ships its own |
 
-Everything else is set in a manifest file.
+Everything else is set in a manifest.
 
 ## Installation
 
-Requires **Linux** and [conda](https://docs.conda.io/). An **NVIDIA GPU (CUDA)** is strongly
-recommended — the demo runs on CPU, but full datasets are impractically slow without one.
-Segmentation uses **Cellpose 4 (cellpose-SAM)**.
+Needs Linux, [conda](https://docs.conda.io/), and an NVIDIA GPU. The demo will run on CPU,
+but full datasets are impractically slow without one. Segmentation uses Cellpose 4
+(cellpose-SAM).
 
 ```bash
-conda env create -f environment.yml   # Python 3.12, PyTorch + CUDA
+conda env create -f environment.yml
 conda activate easipass
-pip install -e .                      # the pipeline and its Python dependencies
+pip install -e .
 ```
 
-`environment.yml` carries only what must come from conda channels — Python and CUDA-enabled
-PyTorch. Everything else is a pip dependency in `pyproject.toml`, and `pip install -e .`
-covers every stage and mode. Optional extras: `.[notebooks]` for Jupyter, `.[analysis]` for
-the analysis notebooks, `.[all]` for both.
+`environment.yml` carries only what has to come from conda channels (Python and CUDA-enabled
+PyTorch). Everything else is a pip dependency, and `pip install -e .` covers every stage and
+mode. Optional extras: `.[notebooks]` for Jupyter, `.[analysis]` for the analysis notebooks.
 
 Cross-modal runs also need [Fiji](https://fiji.sc/)'s BigWarp for placing seed landmarks
 (Plugins > BigDataViewer > Big Warp). See [docs/landmarks.md](docs/landmarks.md).
 
-> If `conda env create` is slow, [mamba](https://mamba.readthedocs.io/) does the same job in
-> seconds. Multi-round registration pulls a pinned BigStream fork from git; to use a local
-> checkout instead, `pip install -e /path/to/bigstream` afterwards.
-
 ## Start with the demo
 
-[`demo/`](demo/README.md) is a small, real, end-to-end example: one two-photon plane from
-mouse JS078 aligned to a 5-channel FISH volume, with a reference result to check yourself
-against. It is the fastest way to confirm your install works and to see what goes in and
-what comes out.
+[`demo/`](demo/README.md) is one two-photon plane from mouse JS078 aligned to a 5-channel
+FISH volume, with a reference result to check yourself against. It is the quickest way to
+confirm your install works and see what goes in and what comes out.
 
 ```bash
-python demo/fetch_demo_data.py     # downloads the imaging data
+python demo/fetch_demo_data.py
 python master_pipeline.py --manifest demo/JS078_demo.hjson
 ```
 
-Nothing to edit — the demo manifest points at its own data. The run pauses three times to
-let you check intermediate output; `demo/README.md` gives the answers.
+Nothing to edit. The run pauses three times to let you check intermediate output;
+`demo/README.md` gives the answers.
 
 ## Running your own data
 
-1. Copy the template that matches what you have:
+**1. Copy a template.**
 
-   | Template | For |
-   |---|---|
-   | [`demo_tiff.hjson`](examples/demo_tiff.hjson) | **Start here.** You supply a 2P mean image per plane as `plane_{N}.tiff` |
-   | [`demo_suite2p.hjson`](examples/demo_suite2p.hjson) | Same, but point at your Suite2p folder and the mean image is pulled from `ops.npy` |
-   | [`demo_hcr_only.hjson`](examples/demo_hcr_only.hjson) | FISH rounds alone, no functional data |
+| Template | For |
+|---|---|
+| [`demo_tiff.hjson`](examples/demo_tiff.hjson) | **Start here.** You supply a 2P mean image per plane as `plane_{N}.tiff` |
+| [`demo_suite2p.hjson`](examples/demo_suite2p.hjson) | Same, but point at your Suite2p folder and the mean image is pulled from `ops.npy` |
+| [`demo_hcr_only.hjson`](examples/demo_hcr_only.hjson) | FISH rounds alone, no functional data |
 
-   A hi-res structural image and the single-round case both work without any manifest
-   change — see the notes at the top of `demo_tiff.hjson`.
+A hi-res image and the single-round case both work with no manifest change; see the notes at
+the top of `demo_tiff.hjson`. [`param_example.hjson`](examples/param_example.hjson) documents
+every tunable option, but it has no `data` section so it is a reference, not a starting point.
 
-   [`param_example.hjson`](examples/param_example.hjson) documents every tunable option in
-   `params`. It is a reference to copy settings out of, not a starting point — it has no
-   `data` section.
-2. Set `base_path` and `sample_name` at the top of your manifest, then put your files here.
-   These are the only inputs; everything under `OUTPUT/` is created for you.
+**2. Put your files where the manifest expects them.**
 
-   ```
-   {base_path}/{sample_name}/
-   ├── 2P/
-   │   ├── plane_0.tiff        your functional mean image, one per plane
-   │   └── plane_0_hires.tiff  optional, and must already be stitched
-   └── HCR/
-       ├── HCR01.tiff          reference round
-       └── HCR02.tiff          any further rounds
-   ```
+`base_path` is the folder that contains your samples, not the sample itself, so several
+manifests can share one `base_path` and differ only by `sample_name`. For data at
+`/data/experiments/M12/`:
 
-   `base_path` is the folder that *contains* your samples, not the sample itself — so
-   several manifests can share one `base_path` and differ only by `sample_name`.
-   Worked example, for data at `/data/experiments/M12/`:
+```
+base_path:   "/data/experiments"
+sample_name: "M12"
+```
+```
+/data/experiments/M12/
+├── 2P/
+│   ├── plane_0.tiff        your functional mean image, one per plane
+│   └── plane_0_hires.tiff  optional, and must already be stitched
+├── HCR/
+│   ├── HCR01.tiff          reference round
+│   └── HCR02.tiff          any further rounds
+└── OUTPUT/                 created by the pipeline
+```
 
-   ```
-   base_path:   "/data/experiments"      ← the folder holding all your samples
-   sample_name: "M12"                    ← this one; outputs are written under it
-   ```
-   ```
-   /data/experiments/M12/2P/plane_0.tiff
-   /data/experiments/M12/HCR/HCR01.tiff
-   /data/experiments/M12/OUTPUT/         ← created by the pipeline
-   ```
+Only the numbers have to line up: `{N}` in `plane_{N}.tiff` matches an entry in
+`functional_planes`, and `{R}` in `HCR{R}.tiff` matches a `round` value. `.tif` and `.tiff`
+both work, case is ignored, and a `{sample_name}_` prefix is accepted. `mouse_name` works as
+a synonym for `sample_name`.
 
-   Only the numbers have to line up: `{N}` in `plane_{N}.tiff` matches an entry in
-   `functional_planes`, and `{R}` in `HCR{R}.tiff` matches a `round` value. `.tif` and
-   `.tiff` both work and case is ignored, so `hcr01.TIF` is fine.
-
-   A `{sample_name}_` prefix on the FISH files is also accepted, since that is what the
-   pipeline writes once rounds are registered. `mouse_name` works as a synonym for
-   `sample_name`.
-
-3. Run:
+**3. Run.**
 
 ```bash
 python master_pipeline.py --manifest examples/your_manifest.hjson
 ```
 
-A manifest with no `two_photon_imaging` section runs FISH rounds only; nothing extra to
-pass. Use `--only_hcr` when you want to skip the functional half of a manifest that has one.
+A manifest with no `two_photon_imaging` section runs FISH rounds only, with nothing extra to
+pass. Use `--only_hcr` to skip the functional half of a manifest that has one.
 
-Cross-modal alignment is the step most likely to need another attempt — it depends on your
-seed landmarks, the functional segmentation, and whether the recovered tissue actually
-contains the imaged field. Add `--check_alignment` to settle that first:
+Cross-modal alignment is the step most likely to need another attempt, since it depends on
+your seed landmarks, the functional segmentation, and whether the recovered tissue actually
+contains the imaged field. `--check_alignment` settles that first:
 
 ```bash
 python master_pipeline.py --manifest examples/your_manifest.hjson --check_alignment
 ```
 
-This segments the reference FISH round only, registers and matches the functional planes to
-it, reports the match rate, and stops — so the later rounds need not even be imaged yet.
-Review the overlays in `OUTPUT/2P/registered/QualityCheck/`, then re-run the same command
-without the flag to segment the remaining rounds and build the output tables. Everything the
-check produced is reused.
+That segments the reference round only, registers and matches the functional planes to it,
+reports the match rate, and stops, so the later rounds need not even be imaged yet. Review
+the overlays in `OUTPUT/2P/registered/QualityCheck/`, then re-run without the flag to finish.
+Everything the check produced is reused.
 
 ## What it does
 
@@ -161,20 +142,18 @@ Output
                                      intensities across rounds, match-quality scores
 ```
 
-With `--only_hcr`, steps 4–7 are skipped and cells are matched across FISH rounds only.
-
-> **Round-to-round registration** uses cell centroids from the segmentation, not detected
-> fluorescent spots. If rounds register poorly, tune `HCR_to_HCR_registration.global` and
-> `.local`: lower `match_threshold` (0.3 → 0.2) to accept weaker centroid correspondences,
-> lower `count_floor` / `match_floor` to let sparse blocks contribute, and widen
-> `context_radius_um` for tissue with less distinctive local geometry. Check the reference
-> round's Cellpose segmentation first — every centroid comes from it.
+Round-to-round registration uses cell centroids from the segmentation, not detected
+fluorescent spots. If rounds register poorly, check the reference round's Cellpose
+segmentation first, since every centroid comes from it. Then tune
+`HCR_to_HCR_registration.global` and `.local`: lower `match_threshold` (0.3 to 0.2) to accept
+weaker correspondences, lower `count_floor` / `match_floor` to let sparse blocks contribute,
+and widen `context_radius_um` for tissue with less distinctive local geometry.
 
 ## What you get
 
-The primary product is a per-cell matching table,
+The main product is a per-cell matching table at
 `OUTPUT/MERGED/aligned_masks/twop_plane{N}_to_HCR01.csv`. Each row is a candidate
-functional↔FISH cell pair; `is_best_match` marks the accepted 1:1 call.
+functional/FISH cell pair, and `is_best_match` marks the accepted 1:1 call.
 
 | Column | Meaning |
 |---|---|
@@ -187,102 +166,75 @@ functional↔FISH cell pair; `is_best_match` marks the accepted 1:1 call.
 | `somaprint_best_score`, `somaprint_second_score` | Its best and runner-up scores |
 | `somaprint_confident` | Whether best separates significantly from runner-up |
 
-```
-mask1,mask2,intersection,...,iou_at_mask1_z,...,is_best_match,somaprint_hcr_label,...,somaprint_confident
-1,20646,117,...,0.2875,...,True,20646,...,True
-1,20482,7,...,0.0109,...,False,20646,...,True
-2,18531,0,...,0.0000,...,False,18531,...,False
-```
+Both matchers are reported for every cell rather than reconciled, so you can set your own
+thresholds. Alongside it, `OUTPUT/MERGED/aligned_extracted_features/full_table_*.pkl` joins
+these matches to per-gene intensities across all rounds.
 
-Both matchers are reported for every cell rather than reconciled for you, so you can set
-your own thresholds. Alongside it, `OUTPUT/MERGED/aligned_extracted_features/full_table_*.pkl`
-joins these matches to the per-gene intensities across all FISH rounds.
-
-In the demo, 1,199 of the 1,439 functional cells segmented in the plane get a 1:1
-overlap match — **83%** — with a median overlap of 0.29 in the functional plane.
-Soma-print, the independent geometric matcher, confidently calls 1,149. Both are reported
-per cell rather than reconciled, so the two rates differ and neither is "the" answer. A
-tracked copy of the table is in [`demo/completed/`](demo/completed/README.md) to diff your
-run against.
+In the demo, 1,199 of the 1,439 segmented functional cells get a 1:1 overlap match (83%),
+with a median overlap of 0.29 in the functional plane. Soma-print confidently calls 1,149.
+The two rates differ because the matchers are independent. A tracked copy of the table is in
+[`demo/completed/`](demo/completed/README.md) to diff your run against.
 
 ## Manifest
 
-The manifest is an [HJSON](https://hjson.github.io/) file — JSON with comments and relaxed
-syntax. It has two top-level sections: `data` (what you're processing) and `params` (how).
+An [HJSON](https://hjson.github.io/) file (JSON with comments and relaxed syntax) with two
+sections: `data` for what you are processing, `params` for how.
 
-### `data`
+**`data`**
 
 | Field | Description |
 |---|---|
-| `base_path` | Root directory holding your experiment folders |
-| `sample_name` | Folder name for this sample. **Outputs are written under this name.** `mouse_name` is accepted as a synonym |
-| `HCR_confocal_imaging.rounds` | One entry per FISH round: round id, channel names, voxel resolution |
+| `base_path` | Folder containing your samples |
+| `sample_name` | Folder name for this sample. Outputs are written under it. `mouse_name` is a synonym |
+| `HCR_confocal_imaging.rounds` | One entry per round: id, channel names, voxel resolution |
 | `HCR_confocal_imaging.reference_round` | The round all others register to. Pick the one with the best signal |
-| `two_photon_imaging.sessions` | Functional session config. Omit entirely for FISH-only runs |
+| `two_photon_imaging.sessions` | Functional session config. Omit for FISH-only runs |
 
-Per FISH round:
+Per round: `round` (e.g. `"01"`), `channels` (the nuclear stain used for registration comes
+first), `resolution` (voxel size `[x, y, z]` in microns, from your confocal metadata).
 
-| Field | Description |
-|---|---|
-| `round` | Round identifier, e.g. `"01"` |
-| `channels` | Channel names. The nuclear/cytoplasmic stain used for registration comes first |
-| `resolution` | Voxel size `[x, y, z]` in microns, from your confocal metadata |
+Per session: `functional_planes` (the first is the reference plane for landmark alignment)
+and `input_format`.
 
-Per functional session:
-
-| Field | Description |
-|---|---|
-| `functional_planes` | Planes to process. **The first is the reference plane** for landmark alignment |
-| `input_format` | How the functional side is read — see below |
-
-### `params`
+**`params`**
 
 | Section | Description |
 |---|---|
-| `HCR_to_HCR_registration` | Round-to-round global and local registration settings |
-| `HCR_cellpose` | Cellpose model and parameters for 3D FISH segmentation |
-| `2p_cellpose` | Cellpose model and parameters for 2D functional segmentation |
+| `HCR_to_HCR_registration` | Round-to-round global and local registration |
+| `HCR_cellpose`, `2p_cellpose` | Cellpose model and parameters for each side |
 | `twop_to_hcr_registration` | Cross-modal cascade: tile sizes, search ranges, thresholds |
 | `intensity_extraction` | Background settings for probe intensity measurement |
 | `rotation_2p_to_HCR` | Coarse rotation/flip bringing the functional image into FISH orientation |
 
-[`examples/param_example.hjson`](examples/param_example.hjson) documents every knob with its
-default and when to change it.
+[`param_example.hjson`](examples/param_example.hjson) documents every option with its default
+and when to change it.
 
 ### Functional input formats
 
-Set per session by `input_format`:
-
-| Value | Reads | Use when |
+| `input_format` | Reads | Use when |
 |---|---|---|
 | `tiff` | `2P/plane_{N}.tiff` mean images | **The standard path.** Any microscope, any preprocessing |
 | `suite2p` | An existing Suite2p output folder | You already ran Suite2p and want the mean image pulled from it |
 | `sbx` | ScanBox `.sbx` via Suite2p | Andermann-lab internal acquisition format |
 
-`tiff` is the path this pipeline is built around and the one the demo uses. `sbx` exists for
-in-house acquisition and is not expected to be useful outside the lab.
-
-`input_format` is **required** whenever there is a `two_photon_imaging` section. There is no
-default, an unrecognised value is an error, and there is no command-line switch that
-overrides it.
+`input_format` is required whenever there is a `two_photon_imaging` section. There is no
+default, an unrecognised value is an error, and no command-line switch overrides it.
 
 ### Hi-res structural images
 
 If you acquired a higher-resolution structural image of the same field, supply it as
-`2P/plane_{N}_hires.tiff` and EASI-PASS will use it as a bridge: the low-res mean image is
-placed into it, and the alignment to the FISH volume is computed at the higher resolution.
-The image must already be stitched.
+`2P/plane_{N}_hires.tiff`. The low-res mean image is placed into it and the alignment to the
+FISH volume is computed at the higher resolution. The image must already be stitched.
 
-> **On tile stitching.** `easipass/tiling.py` and `easipass/auto_stitching.py` do assemble
-> tiles into a stitched field, by phase correlation between adjacent tiles with a
-> median-shift consensus layout. This works, but it assumes our ScanBox acquisition's tile
-> geometry and naming, so it is **not a supported general feature** — supply an
-> already-stitched image instead. Generalizing it mainly needs an agreed tile-input format
-> (per-tile files plus a nominal grid position); that is an open contribution we'd welcome.
+> `easipass/tiling.py` and `easipass/auto_stitching.py` do assemble tiles by phase
+> correlation with a median-shift consensus layout, but they assume our ScanBox tile geometry
+> and naming, so this is not a supported general feature. Supply an already-stitched image.
+> Generalizing it mainly needs an agreed tile-input format (per-tile files plus a nominal
+> grid position), which is an open contribution we would welcome.
 
 ## What the pipeline writes
 
-Everything lands under `{base_path}/{sample_name}/OUTPUT/`, alongside your inputs:
+Everything lands under `{base_path}/{sample_name}/OUTPUT/`:
 
 ```
 OUTPUT/
@@ -298,51 +250,48 @@ OUTPUT/
     └── aligned_extracted_features/   final tables, matches joined to genes
 ```
 
-The two you will actually open are `MERGED/aligned_masks/` for the matches and
-`2P/registered/QualityCheck/` for the overlays that tell you whether alignment worked.
+The two worth opening are `MERGED/aligned_masks/` for the matches and
+`2P/registered/QualityCheck/` for the overlays that show whether alignment worked.
 
 ## Re-running
 
-The pipeline skips a step when its output already exists, so an interrupted run resumes
-where it stopped. Delete a step's output files to redo just that step, or the whole
-`OUTPUT/` folder for a clean run.
+The pipeline skips a step when its output already exists, so an interrupted run resumes where
+it stopped. Delete a step's output to redo just that step, or the whole `OUTPUT/` folder for a
+clean run.
 
 ## Troubleshooting
 
-**`pynwb not installed ...`** — printed by Suite2p on every import. NWB is a file format
-EASI-PASS never touches. Nothing is missing.
+**`pynwb not installed ...`** Printed by Suite2p on every import. NWB is a format EASI-PASS
+never touches, so nothing is missing.
 
-**`could not start: No module named 'registrations'`** — an internal module name, so this is
-never the real cause. The startup message names what is actually wrong; the usual answer is
-that the environment is not active (`conda activate easipass`).
+**`could not start: No module named 'registrations'`** An internal module name, so never the
+real cause. The startup message names what is actually wrong; usually the environment is not
+active (`conda activate easipass`).
 
-**Alignment looks wrong** — see [docs/landmarks.md](docs/landmarks.md), which covers the
-common failure modes and what each one points to.
+**Alignment looks wrong** See [docs/landmarks.md](docs/landmarks.md), which covers the common
+failure modes and what each one points to.
 
 ## Source layout
 
-Where to look first, by what you are trying to change:
-
 | File | Purpose |
 |---|---|
-| `master_pipeline.py` | Orchestrator and CLI — the order every step runs in |
+| `master_pipeline.py` | Orchestrator and CLI, and the order every step runs in |
 | `easipass/meta.py` | Manifest parsing and validation |
-| `easipass/importers.py` | Dispatch on `input_format` (tiff / suite2p / sbx) |
-| `easipass/functional.py` | Reads the functional side and applies the coarse rotation |
+| `easipass/importers.py` | Dispatch on `input_format` |
+| `easipass/functional.py` | Reads the functional side, applies the coarse rotation |
 | `easipass/segmentation.py` | Cellpose segmentation, mask matching, merged tables |
 | `easipass/registrations.py` | Registration orchestration |
 | `easipass/registrations_utils.py` | Cross-modal registration algorithms |
 | `easipass/hcr_centroid_registration.py` | Centroid-seeded round-to-round registration |
-| `easipass/somaprint.py` | Geometric cross-modal cell matcher |
-| `easipass/somaprint_hcr.py` | Geometric round-to-round cell matcher |
+| `easipass/somaprint.py`, `somaprint_hcr.py` | Geometric cell matchers, cross-modal and round-to-round |
 
-The rest of `easipass/` is supporting code: tile stitching, the automation checkpoints, the
-BigStream wrappers, and analysis helpers.
+The rest of `easipass/` is supporting code: tile stitching, automation checkpoints, BigStream
+wrappers, and analysis helpers.
 
 ## Citation
 
-If you use EASI-PASS, please cite the accompanying paper. Citation details will be added
-here on publication; see [CITATION.cff](CITATION.cff).
+If you use EASI-PASS, please cite the accompanying paper. Details will be added here on
+publication; see [CITATION.cff](CITATION.cff).
 
 ## License
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -6,7 +6,7 @@ it to a full-frame HCR confocal volume, segments cells in both, matches them, an
 a per-cell table joining 2P identity to the 5 HCR gene channels.
 
 This is the **stills / image-align** use case (`input_format: "tiff"`): a static 2P image, not a
-movie, so there are no activity traces — just cross-modal alignment + the molecular join.
+movie, so there are no activity traces, just cross-modal alignment and the molecular join.
 
 ## What's in this folder
 
@@ -30,14 +30,15 @@ demo/
 ```
 
 You run the pipeline on **`demo_pre_run/`**, then compare your result against the golden
-table in **`completed/`** — 398 KB, tracked in git, so the check costs no download. Only
+table in **`completed/`**, which is 398 KB and tracked in git, so the check costs no
+download. Only
 the text files and that table are in the repo; the imaging data is a GitHub release asset
 fetched by `fetch_demo_data.py`.
 
 ## Prerequisites
 
 - The pipeline environment with **Cellpose 4 / cellpose-SAM** (the demo manifest uses
-  `model_path: "cpsam"`, which auto-downloads — no model files to place). See the repo
+  `model_path: "cpsam"`, which auto-downloads, so there are no model files to place). See the repo
   README's install section for the conda env.
 - A GPU is recommended (`gpu: true` in the manifest); set `gpu: false` to run on CPU (slower).
 
@@ -78,13 +79,13 @@ OUTPUT/2P/registered/QualityCheck/plane0_AFTER_registration_overlay.tiff   # vis
 ```
 Compare `twop_plane0_to_HCR01.csv` against the golden copy in **`completed/`**
 (`twop_plane0_to_HCR01.csv` + expected numbers in `completed/README.md`). Cell counts
-and matches should be close; exact values depend on GPU / Cellpose version. The healthy
+and matches should be close; exact values depend on GPU and Cellpose version. The healthy
 signal is a 2P→HCR cascade `Final: IoU ~0.48` with an accepted small global shift.
 
 ## Regenerating the demo data (maintainers)
 
-`demo_pre_run/` is a *subset* of the full-resolution JS078 dataset — one functional plane
-(plane 0) and one HCR round (01) — assembled with:
+`demo_pre_run/` is a subset of the full-resolution JS078 dataset: one functional plane
+(plane 0) and one HCR round (01), assembled with:
 ```bash
 python make_demo_data.py \
   --src /path/to/EASI_FISH/pipeline/JS078 \
@@ -93,13 +94,13 @@ python make_demo_data.py \
 The golden table in `completed/` is the match CSV from a validated run of that data; it is
 what users diff against. Build the release archive as noted in `fetch_demo_data.py`, attach
 it to a GitHub release, and update `RELEASE_BASE` and the sha256 there.
-Everything is shipped at **full resolution and full frame** — the HCR volume is copied
+Everything is shipped at full resolution and full frame. The HCR volume is copied
 verbatim (~774 MB, all 5 gene channels, all 39 Z slices), and the BigWarp landmarks are
 copied verbatim (no coordinate shift, since nothing is cropped).
 
 **Why no spatial crop:** an earlier version XY-cropped the HCR volume to save size, but
 2P→HCR registration needs the surrounding HCR image context (and several landmark cells
-sit near the tissue edge). Cropping halved alignment quality — plane0 best-match median
-IoU dropped 0.38 → 0.16 vs the uncropped run — and made the overlay masks look
+sit near the tissue edge). Cropping halved alignment quality (plane0 best-match median
+IoU dropped 0.38 to 0.16 versus the uncropped run) and made the overlay masks look
 misaligned. The data is a release asset, not a tracked file, so full-frame size is not a
 repo concern.

--- a/demo/completed/README.md
+++ b/demo/completed/README.md
@@ -1,7 +1,7 @@
 # Reference output ("the complete")
 
 This is the expected result of running the demo, so you can confirm your own run
-produced something sensible. It is intentionally lightweight — a single small CSV,
+produced something sensible. It is deliberately lightweight: a single small CSV,
 not the multi-GB OUTPUT tree the pipeline generates (HCR masks alone are ~600 MB).
 Ship inputs (`../demo_pre_run/`) + this golden output; regenerate the heavy intermediates
 by running the pipeline.
@@ -21,18 +21,18 @@ as `OUTPUT/MERGED/aligned_extracted_features/full_table_*.pkl`.)
 |---|---|
 | HCR cells segmented (whole 3D volume, all 39 z-slices) | ~21,000 |
 | 2P cells segmented in the plane | 1,439 |
-| 2P cells matched 1:1 (IoU) | 1,199 — **83% of the 1,439 segmented** |
-| 2P cells soma-print called confidently | 1,149 — 80% |
+| 2P cells matched 1:1 (IoU) | 1,199, or **83% of the 1,439 segmented** |
+| 2P cells soma-print called confidently | 1,149, or 80% |
 | best-match median IoU (at 2P z) | 0.29 |
 | 2P→HCR cascade final overlay IoU | ~0.48 |
 | global coarse shift found | dx ≈ −18 px, accepted (no `[WARN] Global rejected`) |
 
 Note the two cell counts are not comparable directly: the ~21,000 FISH cells span the whole
 3D volume, while one 2P plane intersects only a thin slab of it. The match rate to judge your
-run by is **matched / 2P cells segmented**, i.e. ~83%. The console prints the stricter
-**matched / cells that overlap anything** instead, which is ~91%.
+run by is matched over cells segmented, so ~83%. The console prints the stricter
+matched over cells that overlap anything, which is ~91%.
 
 If your `Final: IoU` is ~0.48 and the global shift is a small (~tens of px) accepted
 value, the 2P→HCR overlay is correct. A railed shift (e.g. `dy=+100`) that gets
-rejected means the low-res→hi-res placement was regenerated instead of kept — re-run
-and answer **n** to the low-res→hi-res overwrite prompt (see `../README.md`).
+rejected means the low-res to hi-res placement was regenerated rather than kept. Re-run
+and answer **n** to that overwrite prompt (see `../README.md`).


### PR DESCRIPTION
Down from 349 lines to 298, mostly by cutting restatement: the manifest tables repeated what the templates already show, and several paragraphs said the same thing twice in different words. The reference material stays, since it is what someone comes back for.

