### PR TITLE
Let a corrected channel name reach the tables it already wrote

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -167,8 +167,40 @@ functional/FISH cell pair, and `is_best_match` marks the accepted 1:1 call.
 | `somaprint_confident` | Whether best separates significantly from runner-up |
 
 Both matchers are reported for every cell rather than reconciled, so you can set your own
-thresholds. Alongside it, `OUTPUT/MERGED/aligned_extracted_features/full_table_*.pkl` joins
-these matches to per-gene intensities across all rounds.
+thresholds.
+
+### The feature table
+
+`OUTPUT/MERGED/aligned_extracted_features/full_table_{feature}_twop_plane{N}.csv` (and `.pkl`)
+joins those matches to per-gene intensities. One row per FISH cell in the reference round, one
+file per feature, single header row.
+
+| Column | Meaning |
+|---|---|
+| `mask_id_main` | The FISH cell this row is about |
+| `{feature}_round_{R}_{gene}` | Intensity of that gene in that round, e.g. `mean_round_01_PDYN` |
+| `twoP_mask`, `twoP_iou` | Functional cell matched by overlap, and that overlap |
+| `twoP_somaprint_mask`, `twoP_somaprint_confident` | The geometric matcher's call, and its confidence |
+| `round_{R}_iou_match`, `round_{R}_iou` | Cell in round R by overlap alone, and that overlap |
+| `round_{R}_hybrid_match` | Cell in round R by the full matcher |
+| `round_{R}_matched_by` | `overlap` if it cleared the IoU and neighbourhood gates, `somaprint` if geometry recovered it |
+| `round_{R}_somaprint_score`, `_second_score` | Scores behind a recovery, blank for a gate-clearing match |
+| `plane` | Which functional plane this file covers |
+
+Every round names its own round, reference included, so no round is a special case. The gene
+columns are joined on `round_{R}_hybrid_match`, so that column says whose intensities are on
+the row. `round_{R}_iou_match` is what overlap alone would have said, which is how you check
+the two against each other:
+
+```python
+matched   = df.round_02_hybrid_match.notna()
+by_iou    = df.round_02_iou_match.notna()
+recovered = df.round_02_matched_by == 'somaprint'
+```
+
+Sizes, containments and intersections are not repeated here. They stay in
+`aligned_masks/{pair}.csv` above, and 3D cell sizes come straight from the published mask
+TIFFs with one `np.unique`.
 
 In the demo, 1,199 of the 1,439 segmented functional cells get a 1:1 overlap match (83%),
 with a median overlap of 0.29 in the functional plane. Soma-print confidently calls 1,149.

--- a/demo/README.md
+++ b/demo/README.md
@@ -74,7 +74,7 @@ Both commands run from the repository root. There is nothing to edit: the manife
 The pipeline writes its results under `demo_pre_run/JS078_demo/OUTPUT/`. The key files:
 ```
 OUTPUT/MERGED/aligned_masks/twop_plane0_to_HCR01.csv          # per-cell 2P<->HCR matches
-OUTPUT/MERGED/aligned_extracted_features/full_table_*.pkl     # matches joined to the 5 HCR gene channels
+OUTPUT/MERGED/aligned_extracted_features/full_table_*.csv     # matches joined to the 5 HCR gene channels
 OUTPUT/2P/registered/QualityCheck/plane0_AFTER_registration_overlay.tiff   # visual check
 ```
 Compare `twop_plane0_to_HCR01.csv` against the golden copy in **`completed/`**

--- a/demo/completed/README.md
+++ b/demo/completed/README.md
@@ -13,7 +13,7 @@ The per-cell 2P→HCR matching table produced at
 Each row is a candidate 2P↔HCR mask pair; `is_best_match == True` marks the accepted
 1:1 match, and the `somaprint_*` columns are the parallel geometric matcher's call.
 (The full per-cell feature table joined to the 5 HCR gene channels is also produced,
-as `OUTPUT/MERGED/aligned_extracted_features/full_table_*.pkl`.)
+as `OUTPUT/MERGED/aligned_extracted_features/full_table_*.csv` and `.pkl`.)
 
 ## Expected numbers (GPU + cellpose-SAM; yours will be close, not identical)
 

--- a/easipass/analysis_utils.py
+++ b/easipass/analysis_utils.py
@@ -592,12 +592,14 @@ def get_gene_column(df: pd.DataFrame, gene: str, round_num: str = '01',
         # Build list of alternatives in order of preference
         alternatives = []
 
-        # 1. Flattened MultiIndex format (from smart_merge_planes)
-        # e.g., 'mean_medflt_3x4x4_PDYN' or 'mean_medflt_3x4x4_round_02_TAC1'
+        # 1. The table merge_masks writes: the round is always named, reference included.
+        # e.g. 'mean_round_01_PDYN', 'mean_round_02_TAC1'
+        alternatives.append(f'{feature_type}_round_{round_num}_{gene}')
+
+        # 1b. Tables written before the reference round carried its number, and the
+        # flattened MultiIndex from smart_merge_planes, e.g. 'mean_medflt_3x4x4_PDYN'
         if round_num == '01':
             alternatives.append(f'{feature_type}_{gene}')
-        else:
-            alternatives.append(f'{feature_type}_round_{round_num}_{gene}')
 
         # 2. Simple gene name (round 01 only)
         alternatives.append(gene)

--- a/easipass/segmentation.py
+++ b/easipass/segmentation.py
@@ -2194,8 +2194,12 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
             ref_mask_ids, twoP_soma_metrics_dict.get('somaprint_second_score', {}))
         reference_round_intensities_pivot['twoP_somaprint_mask_size'] = _lookup_column(
             ref_mask_ids, twoP_soma_metrics_dict.get('somaprint_mask_size', {}))
-        reference_round_intensities_pivot['twoP_somaprint_confident'] = _lookup_column(
-            ref_mask_ids, twoP_soma_metrics_dict.get('somaprint_confident', {}))
+        # A cell soma-print never picked is not confident, so this is False, not missing --
+        # matching how somaprint_confident is stored on the matching CSVs. Left as None it
+        # came back from csv as NaN in an object column, where `~col` silently misbehaves.
+        reference_round_intensities_pivot['twoP_somaprint_confident'] = pd.Series(
+            _lookup_column(ref_mask_ids, twoP_soma_metrics_dict.get('somaprint_confident', {})),
+            index=reference_round_intensities_pivot.index).fillna(False).astype(bool)
 
         # HCR round columns
         for j in range(len(HCR_round_mapping_dict)):

--- a/easipass/segmentation.py
+++ b/easipass/segmentation.py
@@ -541,6 +541,33 @@ def get_neuropil_mask_square(volume, radius, bound, inds):
     return all_masks_locs
 
 
+def _flatten_gene_pivot(piv, feature, round_name):
+    """Collapse a pivoted round to a single header row.
+
+    pd.pivot leaves a two-level column index, (feature, gene) for the gene columns and
+    (name, '') for everything else. Gene columns become `{feature}_round_{R}_{gene}`. The
+    round is spelled out for every round INCLUDING the reference, so no round is a special
+    case for whoever reads the table.
+    """
+    piv.columns = [f'{feature}_round_{round_name}_{gene}' if gene else str(top)
+                   for top, gene in piv.columns]
+    return piv
+
+
+def _merged_table_needs_rebuild(path, newest_source):
+    """Whether a merged feature table has to be rebuilt: missing, older than the intensities
+    it is a pivot of, or still carrying the old two-level column header."""
+    if not path.exists():
+        return True
+    if path.stat().st_mtime < newest_source:
+        return True
+    try:
+        columns = pd.read_pickle(path).columns
+    except Exception:
+        return True      # unreadable here (foreign pandas/pyarrow pickle) -- just rebuild it
+    return isinstance(columns, pd.MultiIndex)
+
+
 def _stored_channel_names(df):
     """The channel_name recorded per channel index in an existing intensities table."""
     if not {'channel', 'channel_name'}.issubset(df.columns):
@@ -2059,14 +2086,16 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
     rebuilt_stale = 0
     for feature in tqdm(features_to_extract, desc="Merging features"):
         merged_table_file_path = merged_table_path / f'full_table_{feature}_twop_plane{plane}.pkl'
+        if not _merged_table_needs_rebuild(merged_table_file_path, newest_source):
+            skipped_features.append(feature)
+            continue
         if merged_table_file_path.exists():
-            if merged_table_file_path.stat().st_mtime >= newest_source:
-                skipped_features.append(feature)
-                continue
             rebuilt_stale += 1
 
         # Pivot reference round for this feature
         reference_round_intensities_pivot = pd.pivot(reference_round_intensities, index='mask_id', columns=['channel_name'], values=[feature]).reset_index()
+        reference_round_intensities_pivot = _flatten_gene_pivot(
+            reference_round_intensities_pivot, feature, reference_round['round'])
         reference_round_intensities_pivot.rename(columns={'mask_id':'mask_id_main'},inplace=True)
 
         # Pivot each HCR round for this feature
@@ -2077,7 +2106,9 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
                 rprint(f"[yellow]Feature '{feature}' not found in round {HCR_round_to_register}[/yellow]")
                 HCR_rounds_intensities_pivot.append(pd.DataFrame())
                 continue
-            HCR_rounds_intensities_pivot.append(pd.pivot(HCR_round_intensities, index='mask_id', columns=['channel_name'], values=[feature]).reset_index())
+            HCR_rounds_intensities_pivot.append(_flatten_gene_pivot(
+                pd.pivot(HCR_round_intensities, index='mask_id', columns=['channel_name'], values=[feature]).reset_index(),
+                feature, HCR_round_to_register))
 
         ####       ####
         ###  MATCH  ###
@@ -2190,7 +2221,9 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
         ####       ####
         ###  MERGE  ###
         ####       ####
-        HCR_main_pivot_merged = reference_round_intensities_pivot.copy().reset_index()
+        # drop=True: the pivot was already reset above, so a bare reset_index() here only
+        # added a stray 'index' column of 0..n-1 to the published table. Nothing reads it.
+        HCR_main_pivot_merged = reference_round_intensities_pivot.copy().reset_index(drop=True)
 
         for j in range(len(HCR_round_mapping_dict)):
             round_mask_name = f'round_{HCR_rounds_names[j]}_mask'
@@ -2209,6 +2242,9 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
         # Add 'plane' column for clarity (each plane gets separate file)
         HCR_main_pivot_merged['plane'] = plane
         HCR_main_pivot_merged.to_pickle(merged_table_file_path)
+        # A pickle only opens in a pandas close enough to the one that wrote it, and newer
+        # pandas stores its strings via pyarrow. The csv is the copy anyone can open.
+        HCR_main_pivot_merged.to_csv(merged_table_file_path.with_suffix('.csv'), index=False)
 
     if skipped_features:
         rprint(f"[dim]Skipped {len(skipped_features)} existing features[/dim]")

--- a/easipass/segmentation.py
+++ b/easipass/segmentation.py
@@ -1894,7 +1894,7 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
         """
         if not {'somaprint_confident', 'somaprint_hcr_label'}.issubset(matching_df.columns):
             return {}, {}
-        # Confidence outranks raw score, as in _build_consensus_lookups: the
+        # Confidence outranks raw score, as in _build_round_lookups: the
         # score scale is only meaningful within a confidence class, so sorting
         # on score alone let an unconfident pick take an HCR cell from a
         # confident one.
@@ -1920,19 +1920,26 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
         }
         return mapping, metrics
 
-    def _build_consensus_lookups(matching_df):
-        """HCR↔HCR partner per reference cell, consensus of the two matchers: the
-        hybrid somaprint pick where present, else the IoU best-match. Returns
+    def _build_round_lookups(matching_df):
+        """HCR↔HCR partners per reference cell, as TWO independent answers.
 
-          mapping        {ref_label → mov_label}   (drives round_{R}_mask / gene join)
-          metrics        {METRIC_COLUMN → {ref → value}}  IoU/containment/size of the
-                         CHOSEN pair (not the IoU best-match row — so a soma-recovered
-                         pair carries its own low overlap, the recovery signal)
-          extras         {match_source / somaprint_best_score / somaprint_second_score
-                          → {ref → value}}; empty when the CSV predates somaprint.
+        The two matchers used to be blended into one consensus column, which meant the
+        published table could not answer "who did plain IoU pick?" at all -- that answer was
+        computed, used to fill gaps, and thrown away. Both are now returned unmixed and both
+        are published, so every question is one condition on one column.
 
-        Falls back to pure IoU best-match (empty extras) on legacy CSVs, so disabling
-        params.somaprint_hcr reproduces the historical table exactly.
+          iou_map      {ref → mov}   plain IoU best-match, no cutoffs
+          iou_metric   {ref → iou}   overlap of THAT pair
+          soma_map     {ref → mov}   the hybrid's pick: a strict-IoU anchor
+                                     (own IoU and neighbourhood IoU both over their gates)
+                                     or, failing that, a soma-print rescue
+          soma_extra   {matched_by / somaprint_score / somaprint_second_score → {ref → v}};
+                       empty when somaprint_hcr did not run, and then soma_map is empty too.
+
+        Quality is reported per stage, because the two are not comparable: an anchor is
+        judged by its overlap, a rescue by how far its best soma score beats the runner-up.
+        A rescue can legitimately have almost no overlap -- that is the point of it -- so
+        its IoU is not a quality signal and is not carried.
         """
         if 'is_best_match' in matching_df.columns:
             iou_best = matching_df[matching_df['is_best_match'] == True]
@@ -1940,59 +1947,37 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
             iou_best = matching_df
         iou_map = {int(m2): int(m1) for m1, m2 in iou_best[['mask1', 'mask2']].values}
 
-        has_soma = {'somaprint_confident', 'somaprint_hcr_label'}.issubset(matching_df.columns)
-        extras = {}
-        if not has_soma:
-            mapping = dict(iou_map)
-        else:
-            # one row per moving cell, then dedupe to 1:1 on the reference label
-            # (highest soma score wins; overlap anchors carry NaN and lose ties).
-            # Confidence outranks raw score. Sorting on score alone let an
-            # unconfident pick scoring 90 take a reference cell away from a
-            # confident pick scoring 50, even though the score scale is only
-            # meaningful within a confidence class.
-            soma = (matching_df.dropna(subset=['somaprint_hcr_label'])
-                    .drop_duplicates('mask1')
-                    .sort_values(['somaprint_confident', 'somaprint_best_score'],
-                                 ascending=[False, False])
-                    .drop_duplicates('somaprint_hcr_label'))
-            soma_keys = soma['somaprint_hcr_label'].astype(int)
-            soma_map = dict(zip(soma_keys, soma['mask1'].astype(int)))
-            soma_bs = dict(zip(soma_keys, soma['somaprint_best_score'].astype(float)))
-            soma_ss = dict(zip(soma_keys, soma['somaprint_second_score'].astype(float)))
-            soma_src = (dict(zip(soma_keys, soma['somaprint_source']))
-                        if 'somaprint_source' in soma.columns else {})
-            # soma_map and iou_map are each injective, but their union is not.
-            # When soma-print moves mov cell A from reference X to reference Y
-            # and nobody soma-claims X, the IoU fallback would hand A to X as
-            # well -- A's gene intensities would then be joined onto two
-            # reference cells, with no change in row count to reveal it. A mov
-            # cell already claimed by soma-print is therefore not available to
-            # the fallback, and the unclaimed reference simply goes unmatched.
-            soma_claimed = set(soma_map.values())
-            mapping, src_map = {}, {}
-            for ref in set(iou_map) | set(soma_map):
-                if ref in soma_map:
-                    mapping[ref] = soma_map[ref]
-                    src_map[ref] = soma_src.get(ref, 'somaprint')
-                elif iou_map[ref] not in soma_claimed:
-                    mapping[ref] = iou_map[ref]
-                    src_map[ref] = 'iou'
-            extras = {'match_source': src_map,
-                      'somaprint_best_score': soma_bs,
-                      'somaprint_second_score': soma_ss}
+        iou_metric = {}
+        if 'iou_at_mask1_z' in iou_best.columns:
+            iou_metric = {int(m2): float(v) for m2, v
+                          in zip(iou_best['mask2'], iou_best['iou_at_mask1_z'])}
 
-        # IoU/containment/size of the CHOSEN (mov, ref) pair, looked up per-pair so a
-        # consensus that differs from the IoU best-match still reports its own overlap.
-        pair = list(zip(matching_df['mask1'].astype(int), matching_df['mask2'].astype(int)))
-        metrics = {}
-        for col in METRIC_COLUMNS:
-            if col in matching_df.columns:
-                pair_val = dict(zip(pair, matching_df[col].values))
-                metrics[col] = {ref: pair_val.get((mov, ref)) for ref, mov in mapping.items()}
-            else:
-                metrics[col] = {}
-        return mapping, metrics, extras
+        has_soma = {'somaprint_confident', 'somaprint_hcr_label'}.issubset(matching_df.columns)
+        if not has_soma:
+            return iou_map, iou_metric, {}, {}
+
+        # one row per moving cell, then dedupe to 1:1 on the reference label
+        # (highest soma score wins; overlap anchors carry NaN and lose ties).
+        # Confidence outranks raw score. Sorting on score alone let an
+        # unconfident pick scoring 90 take a reference cell away from a
+        # confident pick scoring 50, even though the score scale is only
+        # meaningful within a confidence class.
+        soma = (matching_df.dropna(subset=['somaprint_hcr_label'])
+                .drop_duplicates('mask1')
+                .sort_values(['somaprint_confident', 'somaprint_best_score'],
+                             ascending=[False, False])
+                .drop_duplicates('somaprint_hcr_label'))
+        soma_keys = soma['somaprint_hcr_label'].astype(int)
+        soma_map = dict(zip(soma_keys, soma['mask1'].astype(int)))
+        soma_extra = {
+            'somaprint_score': dict(zip(soma_keys, soma['somaprint_best_score'].astype(float))),
+            'somaprint_second_score': dict(zip(soma_keys,
+                                               soma['somaprint_second_score'].astype(float))),
+            'matched_by': (dict(zip(soma_keys, soma['somaprint_source']))
+                           if 'somaprint_source' in soma.columns
+                           else {k: 'somaprint' for k in soma_map}),
+        }
+        return iou_map, iou_metric, soma_map, soma_extra
 
     # ========== PRE-LOAD ALL DATA ONCE (optimization: avoid reloading per feature) ==========
 
@@ -2041,6 +2026,7 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
     HCR_rounds_names = register_rounds
     HCR_round_mapping_dict = []
     HCR_round_metrics_dict = []
+    HCR_round_soma_dict = []
     HCR_round_extra_dict = []
     preloaded_round_intensities = {}
 
@@ -2056,12 +2042,12 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
                 f"HCR round mapping file not found: {round_mapping_file_path}\n"
                 f"Please ensure align_masks() has completed for HCR round {HCR_round_to_register}."
             )
-        # Consensus of the IoU and somaprint matchers: round_{R}_mask follows the
-        # hybrid pick where somaprint matched, else the IoU best-match. Built from
-        # the FULL df (somaprint rows include is_best_match=False recoveries).
-        round_mapping, round_metrics, round_extra = _build_consensus_lookups(round_mapping_df)
-        HCR_round_mapping_dict.append(round_mapping)
-        HCR_round_metrics_dict.append(round_metrics)
+        # Both matchers, kept apart. Built from the FULL df (somaprint rows include
+        # is_best_match=False recoveries, which the IoU view filters out).
+        round_iou, round_iou_metric, round_soma, round_extra = _build_round_lookups(round_mapping_df)
+        HCR_round_mapping_dict.append(round_iou)
+        HCR_round_metrics_dict.append(round_iou_metric)
+        HCR_round_soma_dict.append(round_soma)
         HCR_round_extra_dict.append(round_extra)
 
         # Load intensities
@@ -2125,11 +2111,15 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
         # 2P↔HCR (somaprint, geometric matcher):
         #   twoP_somaprint_mask, twoP_somaprint_best_score,
         #   twoP_somaprint_second_score, twoP_somaprint_mask_size
-        # HCR-level (matcher-independent):
-        #   HCR_mask_size
         # HCR round-to-round, one set per non-reference round R:
-        #   round_{R}_mask, round_{R}_iou, round_{R}_containment,
-        #   main_containment_round_{R}, round_{R}_mask_size
+        #   round_{R}_iou_match, round_{R}_iou,
+        #   round_{R}_hybrid_match, round_{R}_matched_by,
+        #   round_{R}_somaprint_score, round_{R}_somaprint_second_score
+        #
+        # Sizes and containments are deliberately NOT repeated here -- every one of them is
+        # already in MERGED/aligned_masks/{pair}.csv (mask1_size, mask2_size, intersection,
+        # both containments), and 3D cell sizes fall out of the published mask tiffs with
+        # one np.unique. This table's job is gene values attached to reference cells.
         #
         # See match_masks() and align_somaprint() docstrings for the
         # precise definition of each metric. `mask_id_main` always refers
@@ -2144,33 +2134,11 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
             'neighborhood_iou':       'twoP_neighborhood_iou',
         }
 
-        def _round_col(metric, round_name):
-            return {
-                'iou_at_mask1_z':         f'round_{round_name}_iou',
-                'containment_2p':         f'round_{round_name}_containment',
-                'containment_hcr_at_z':   f'main_containment_round_{round_name}',
-                'mask1_size':             f'round_{round_name}_mask_size',
-            }[metric]
-
         def _lookup_column(mask_ids, dct):
             """Map an iterable of mask_id_main values through a dict (None if missing)."""
             return [dct.get(i) for i in mask_ids]
 
         ref_mask_ids = reference_round_intensities_pivot.mask_id_main
-
-        # HCR cell size at the warped 2P plane — always populated (matcher-
-        # independent). Drives downstream sliver filtering. In only_hcr mode
-        # there is no 2P plane to project against; fall back to full 3D
-        # voxel counts so the column has stable semantics within the table.
-        from . import somaprint as sp_lib
-        if only_hcr:
-            hcr_size_lookup = sp_lib.compute_full_hcr_sizes(
-                full_manifest, reference_round['round'])
-        else:
-            hcr_size_lookup = sp_lib.compute_plane_projected_hcr_sizes(
-                full_manifest, session, reference_round['round'])
-        reference_round_intensities_pivot['HCR_mask_size'] = _lookup_column(
-            ref_mask_ids, hcr_size_lookup)
 
         # 2P columns — IoU best-match path
         reference_round_intensities_pivot['twoP_mask'] = _lookup_column(ref_mask_ids, twoP_mapping_dict)
@@ -2201,26 +2169,35 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
             _lookup_column(ref_mask_ids, twoP_soma_metrics_dict.get('somaprint_confident', {})),
             index=reference_round_intensities_pivot.index).fillna(False).astype(bool)
 
-        # HCR round columns
+        # HCR round columns. Two matchers, two answers, never blended:
+        #   round_{R}_iou_match     who plain IoU picked      + round_{R}_iou, that pair's overlap
+        #   round_{R}_hybrid_match  who the hybrid picked     + round_{R}_matched_by, which stage
+        #                           ('overlap' = cleared the strict IoU + neighbourhood gates;
+        #                            'somaprint' = rescued geometrically) and, for a rescue,
+        #                           the soma scores it was judged on.
+        # Gene columns are joined on hybrid_match (see the MERGE block below), so that is the
+        # column saying whose intensities are on this row.
+        round_join_cols = []
         for j in range(len(HCR_round_mapping_dict)):
-            HCR_main_2_HCR_round = HCR_round_mapping_dict[j]
-            round_metrics = HCR_round_metrics_dict[j]
             round_name = HCR_rounds_names[j]
-            reference_round_intensities_pivot[f'round_{round_name}_mask'] = _lookup_column(
-                ref_mask_ids, HCR_main_2_HCR_round)
-            for src_col in METRIC_COLUMNS:
-                reference_round_intensities_pivot[_round_col(src_col, round_name)] = _lookup_column(
-                    ref_mask_ids, round_metrics.get(src_col, {}))
-            # Hybrid-matcher provenance (only when somaprint_hcr ran for this round):
-            # which matcher produced round_{R}_mask and the soma scores behind a repair.
+            reference_round_intensities_pivot[f'round_{round_name}_iou_match'] = _lookup_column(
+                ref_mask_ids, HCR_round_mapping_dict[j])
+            reference_round_intensities_pivot[f'round_{round_name}_iou'] = _lookup_column(
+                ref_mask_ids, HCR_round_metrics_dict[j])
+
+            soma_map = HCR_round_soma_dict[j]
             extra = HCR_round_extra_dict[j]
             if extra:
-                reference_round_intensities_pivot[f'round_{round_name}_match_source'] = _lookup_column(
-                    ref_mask_ids, extra.get('match_source', {}))
-                reference_round_intensities_pivot[f'round_{round_name}_somaprint_score'] = _lookup_column(
-                    ref_mask_ids, extra.get('somaprint_best_score', {}))
-                reference_round_intensities_pivot[f'round_{round_name}_somaprint_second_score'] = _lookup_column(
-                    ref_mask_ids, extra.get('somaprint_second_score', {}))
+                reference_round_intensities_pivot[f'round_{round_name}_hybrid_match'] = _lookup_column(
+                    ref_mask_ids, soma_map)
+                for key in ('matched_by', 'somaprint_score', 'somaprint_second_score'):
+                    reference_round_intensities_pivot[f'round_{round_name}_{key}'] = _lookup_column(
+                        ref_mask_ids, extra.get(key, {}))
+                round_join_cols.append(f'round_{round_name}_hybrid_match')
+            else:
+                # somaprint_hcr did not run for this round -- IoU is the only answer there is,
+                # so it is also what the gene columns are joined on.
+                round_join_cols.append(f'round_{round_name}_iou_match')
 
         ####       ####
         ###  MERGE  ###
@@ -2230,7 +2207,8 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
         HCR_main_pivot_merged = reference_round_intensities_pivot.copy().reset_index(drop=True)
 
         for j in range(len(HCR_round_mapping_dict)):
-            round_mask_name = f'round_{HCR_rounds_names[j]}_mask'
+            # Genes follow the hybrid's pick, or IoU's when the hybrid did not run.
+            round_mask_name = round_join_cols[j]
 
             # Skip merge if the intensities DataFrame is empty (feature was missing for this round)
             if HCR_rounds_intensities_pivot[j].empty:
@@ -2317,7 +2295,11 @@ def print_match_summary(full_manifest: dict, all_planes: list):
                 f"soma-print {n_soma} ({100 * n_soma / denom:.0f}%)")
         if soma_matched is not None:
             for r in register_rounds:
-                col = f'round_{r}_mask'
+                # The column the round's gene values were joined on: the hybrid's pick,
+                # or IoU's when somaprint_hcr did not run for that round.
+                col = (f'round_{r}_hybrid_match'
+                       if f'round_{r}_hybrid_match' in df.columns
+                       else f'round_{r}_iou_match')
                 if col in df.columns:
                     in_round = int((soma_matched & df[col].notna()).sum())
                     line += f" → HCR{r}: {in_round}"

--- a/easipass/segmentation.py
+++ b/easipass/segmentation.py
@@ -541,6 +541,56 @@ def get_neuropil_mask_square(volume, radius, bound, inds):
     return all_masks_locs
 
 
+def _stored_channel_names(df):
+    """The channel_name recorded per channel index in an existing intensities table."""
+    if not {'channel', 'channel_name'}.issubset(df.columns):
+        return None      # table predates the channel_name column; nothing to reconcile
+    pairs = df[['channel', 'channel_name']].drop_duplicates()
+    if pairs['channel'].duplicated().any():
+        return None      # one index carries two names; don't try to reconcile it
+    return list(pairs.sort_values('channel')['channel_name'])
+
+
+def _sync_channel_names(pkl_path, csv_path, channels_names, round_folder_name):
+    """Bring an already-extracted intensities table in line with the manifest's channel list.
+
+    Extraction is skipped whenever the pkl exists, so a channel name corrected in the manifest
+    would otherwise never reach the table -- the run reports success and every downstream
+    column keeps the old name. Names are labels on an existing measurement and nothing numeric
+    depends on them, so a pure rename is rewritten in place rather than paying for another
+    neuropil extraction. A change in channel COUNT is a different claim about the image and
+    cannot be patched this way.
+
+    Returns a one-line description of what was renamed, or None if nothing changed.
+    """
+    df = pd.read_pickle(pkl_path)
+    if df.empty:
+        return None
+    stored = _stored_channel_names(df)
+    if stored is None or stored == list(channels_names):
+        return None
+    if len(stored) != len(channels_names):
+        raise ValueError(
+            f"HCR channel-count mismatch for {round_folder_name}: the extracted table has "
+            f"{len(stored)} channels {stored}, the manifest lists {len(channels_names)} "
+            f"{list(channels_names)}.\nNames can be corrected in place, a count cannot -- "
+            f"delete {pkl_path} to re-extract.")
+
+    # Cast back to whatever the column already was -- real tables store this as a pyarrow-backed
+    # string, and .map() alone would quietly hand it back as object dtype.
+    renamed_col = df['channel'].map(dict(enumerate(channels_names)))
+    df['channel_name'] = renamed_col.astype(df['channel_name'].dtype)
+
+    # Write to a sibling temp file and swap it in. This table costs a full neuropil extraction
+    # to rebuild, so a crash partway through a rewrite must not be able to truncate it.
+    for path, writer in ((Path(csv_path), df.to_csv), (Path(pkl_path), df.to_pickle)):
+        tmp = path.with_name(path.name + '.tmp')
+        writer(tmp)
+        tmp.replace(path)
+    changed = [f"{a} -> {b}" for a, b in zip(stored, channels_names) if a != b]
+    return f"  {round_folder_name}: {', '.join(changed)}"
+
+
 def extract_probe_intensity(full_manifest):
     params = full_manifest['params']
     round_to_rounds, reference_round, register_rounds = verify_rounds(full_manifest, parse_registered = True,
@@ -568,6 +618,7 @@ def extract_probe_intensity(full_manifest):
 
     # Check which rounds need processing
     to_process = []
+    renamed = []
     for HCR_round_to_register in all_rounds:
         round_folder_name = get_round_folder_name(HCR_round_to_register, reference_round['round'])
         if HCR_round_to_register == reference_round['round']:
@@ -578,6 +629,19 @@ def extract_probe_intensity(full_manifest):
         pkl_output_path = output_folder / f"{round_folder_name}_probs_intensities.pkl"
         if not pkl_output_path.exists():
             to_process.append((HCR_round_to_register, round_folder_name, channels_names))
+        else:
+            # Already extracted -- the numbers stand, but the manifest may have corrected a name.
+            msg = _sync_channel_names(
+                pkl_output_path,
+                output_folder / f"{round_folder_name}_probs_intensities.csv",
+                channels_names, round_folder_name)
+            if msg:
+                renamed.append(msg)
+
+    if renamed:
+        rprint("[yellow]HCR intensities: channel names updated from the manifest[/yellow]")
+        for msg in renamed:
+            rprint(f"[yellow]{msg}[/yellow]")
 
     # Print summary
     if not to_process:
@@ -1943,6 +2007,9 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
             f"Please ensure extract_probe_intensity() has completed for HCR round {reference_round['round']}."
         )
 
+    # Every merged table is a pivot of these; a table older than its sources is stale.
+    intensity_sources = [ref_intensities_path]
+
     # Pre-load HCR round mappings and intensities (feature-independent)
     HCR_rounds_names = register_rounds
     HCR_round_mapping_dict = []
@@ -1979,15 +2046,24 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
                 f"HCR round intensities not found: {round_intensities_path}\n"
                 f"Please ensure extract_probe_intensity() has completed for HCR round {HCR_round_to_register}."
             )
+        intensity_sources.append(round_intensities_path)
 
     # ========== PROCESS EACH FEATURE (now only pivots, no file I/O) ==========
 
+    # The gene names become COLUMN LABELS in the pivot below, so a name corrected in the
+    # manifest has to reach the merged tables too. Rebuilding one is pivots over data already
+    # loaded above, so rebuild on any source that is newer rather than only on absence.
+    newest_source = max(p.stat().st_mtime for p in intensity_sources)
+
     skipped_features = []
+    rebuilt_stale = 0
     for feature in tqdm(features_to_extract, desc="Merging features"):
         merged_table_file_path = merged_table_path / f'full_table_{feature}_twop_plane{plane}.pkl'
         if merged_table_file_path.exists():
-            skipped_features.append(feature)
-            continue
+            if merged_table_file_path.stat().st_mtime >= newest_source:
+                skipped_features.append(feature)
+                continue
+            rebuilt_stale += 1
 
         # Pivot reference round for this feature
         reference_round_intensities_pivot = pd.pivot(reference_round_intensities, index='mask_id', columns=['channel_name'], values=[feature]).reset_index()
@@ -2136,6 +2212,8 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
 
     if skipped_features:
         rprint(f"[dim]Skipped {len(skipped_features)} existing features[/dim]")
+    if rebuilt_stale:
+        rprint(f"[yellow]Rebuilt {rebuilt_stale} feature table(s) older than the extracted intensities[/yellow]")
 
     rprint("\n" + "="*80)
     rprint("[bold green] Match Aligned Masks COMPLETE[/bold green]")

--- a/easipass/segmentation.py
+++ b/easipass/segmentation.py
@@ -2243,8 +2243,11 @@ def merge_masks(full_manifest: dict, session: dict, only_hcr: bool = False):
         HCR_main_pivot_merged['plane'] = plane
         HCR_main_pivot_merged.to_pickle(merged_table_file_path)
         # A pickle only opens in a pandas close enough to the one that wrote it, and newer
-        # pandas stores its strings via pyarrow. The csv is the copy anyone can open.
-        HCR_main_pivot_merged.to_csv(merged_table_file_path.with_suffix('.csv'), index=False)
+        # pandas stores its strings via pyarrow. The csv is the copy anyone can open. Built
+        # from the same f-string as the pkl: with_suffix() would cut at the first dot in a
+        # feature name (a float in stack_median_filter puts one there).
+        HCR_main_pivot_merged.to_csv(
+            merged_table_path / f'full_table_{feature}_twop_plane{plane}.csv', index=False)
 
     if skipped_features:
         rprint(f"[dim]Skipped {len(skipped_features)} existing features[/dim]")


### PR DESCRIPTION
Intensity extraction skips a round whenever its _probs_intensities.pkl exists, so fixing a mistyped gene in the manifest never reached the output: the run reported success and every downstream column kept the old name. The preflight only ever compared channel count, never identity.

Channel names are labels on an existing measurement, so a pure rename is now rewritten in place instead of paying for another neuropil extraction. The rewrite goes through a sibling temp file and an atomic swap, since that table is expensive to rebuild and a crash partway through must not truncate it. A change in channel count is a different claim about the image and still raises, naming the file to delete.

Those names also become column labels in the merged feature tables, which skipped on mere existence too. They now rebuild whenever an intensities file is newer, which is cheap because the merge step is pivots over data it has already loaded.