### PR TITLE
Trim the docs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -166,7 +166,7 @@ functional/FISH cell pair, and `is_best_match` marks the accepted 1:1 call.
 | `somaprint_best_score`, `somaprint_second_score` | Its best and runner-up scores |
 | `somaprint_confident` | Whether best separates significantly from runner-up |
 
-Both matchers are reported for every cell rather than reconciled, so you can set your own
+Both matchers are reported for every cell and never reconciled, so you set your own
 thresholds.
 
 ### The feature table
@@ -187,10 +187,8 @@ file per feature, single header row.
 | `round_{R}_somaprint_score`, `_second_score` | Scores behind a recovery, blank for a gate-clearing match |
 | `plane` | Which functional plane this file covers |
 
-Every round names its own round, reference included, so no round is a special case. The gene
-columns are joined on `round_{R}_hybrid_match`, so that column says whose intensities are on
-the row. `round_{R}_iou_match` is what overlap alone would have said, which is how you check
-the two against each other:
+The gene columns are joined on `round_{R}_hybrid_match`, so that column says whose intensities
+are on the row, and `round_{R}_iou_match` is what overlap alone would have said:
 
 ```python
 matched   = df.round_02_hybrid_match.notna()
@@ -198,9 +196,7 @@ by_iou    = df.round_02_iou_match.notna()
 recovered = df.round_02_matched_by == 'somaprint'
 ```
 
-Sizes, containments and intersections are not repeated here. They stay in
-`aligned_masks/{pair}.csv` above, and 3D cell sizes come straight from the published mask
-TIFFs with one `np.unique`.
+Sizes and containments are not repeated here; they stay in the matching table above.
 
 In the demo, 1,199 of the 1,439 segmented functional cells get a 1:1 overlap match (83%),
 with a median overlap of 0.29 in the functional plane. Soma-print confidently calls 1,149.
@@ -282,7 +278,8 @@ OUTPUT/
     └── aligned_extracted_features/   final tables, matches joined to genes
 ```
 
-The two worth opening are `MERGED/aligned_masks/` for the matches and
+Tables are written as both `.csv` and `.pkl`. Start with
+`MERGED/aligned_extracted_features/` for the result and
 `2P/registered/QualityCheck/` for the overlays that show whether alignment worked.
 
 ## Re-running

--- a/demo/README.md
+++ b/demo/README.md
@@ -61,12 +61,8 @@ Both commands run from the repository root. There is nothing to edit: the manife
 
    **Answer the prompts as follows:**
    - `Verify 2P cellpose segmentations … press Enter` → press **Enter**.
-   - `Overwrite? [y/n]` (the `[registration] Existing output found …` prompt, low-res→hi-res step) → **n**.
-     This keeps the shipped 2P *placement*. The automated SIFT placement is fragile in
-     the tiff path (on this plane it lands ~100 px off, which makes the 2P→HCR
-     overlay come out stringy); the shipped placement is the production one, so the
-     alignment reproduces the paper-quality overlay. Answering `y` regenerates it and
-     may degrade the result.
+   - `Overwrite? [y/n]` (low-res→hi-res step) → **n**, which keeps the shipped 2P placement.
+     Answering `y` recomputes it and the demo may no longer reproduce.
    - `After checking QA images, choose [y/r/n]` (2P→HCR) → **y**.
 
 ## Expected output
@@ -84,23 +80,17 @@ signal is a 2P→HCR cascade `Final: IoU ~0.48` with an accepted small global sh
 
 ## Regenerating the demo data (maintainers)
 
-`demo_pre_run/` is a subset of the full-resolution JS078 dataset: one functional plane
-(plane 0) and one HCR round (01), assembled with:
+`demo_pre_run/` is one functional plane (0) and one HCR round (01) of JS078, at full
+resolution and full frame:
 ```bash
 python make_demo_data.py \
   --src /path/to/EASI_FISH/pipeline/JS078 \
   --dst ./demo_pre_run/JS078_demo
 ```
-The golden table in `completed/` is the match CSV from a validated run of that data; it is
-what users diff against. Build the release archive as noted in `fetch_demo_data.py`, attach
-it to a GitHub release, and update `RELEASE_BASE` and the sha256 there.
-Everything is shipped at full resolution and full frame. The HCR volume is copied
-verbatim (~774 MB, all 5 gene channels, all 39 Z slices), and the BigWarp landmarks are
-copied verbatim (no coordinate shift, since nothing is cropped).
+Then build the archive as noted in `fetch_demo_data.py`, attach it to a GitHub release, and
+update `RELEASE_BASE` and the sha256 there. The golden table in `completed/` is the match CSV
+from a validated run.
 
-**Why no spatial crop:** an earlier version XY-cropped the HCR volume to save size, but
-2P→HCR registration needs the surrounding HCR image context (and several landmark cells
-sit near the tissue edge). Cropping halved alignment quality (plane0 best-match median
-IoU dropped 0.38 to 0.16 versus the uncropped run) and made the overlay masks look
-misaligned. The data is a release asset, not a tracked file, so full-frame size is not a
-repo concern.
+Do not XY-crop the HCR volume to save size. Registration uses the surrounding tissue context
+and several landmarks sit near the edge; cropping dropped median IoU from 0.38 to 0.16. The
+data is a release asset, so its size is not a repo concern.

--- a/demo/completed/README.md
+++ b/demo/completed/README.md
@@ -34,5 +34,5 @@ matched over cells that overlap anything, which is ~91%.
 
 If your `Final: IoU` is ~0.48 and the global shift is a small (~tens of px) accepted
 value, the 2P→HCR overlay is correct. A railed shift (e.g. `dy=+100`) that gets
-rejected means the low-res to hi-res placement was regenerated rather than kept. Re-run
+rejected means the low-res to hi-res placement was regenerated, not kept. Re-run
 and answer **n** to that overwrite prompt (see `../README.md`).

--- a/docs/landmarks.md
+++ b/docs/landmarks.md
@@ -76,7 +76,7 @@ deleting it.
 The units in columns 6 to 8 are whichever units the volume declares. If the FISH TIFF
 carries no ImageJ micron calibration, BigWarp exports **pixels**, the pipeline divides them
 by a micron resolution anyway, and every landmark lands at the wrong scale. Nothing
-downstream can detect this, so the pipeline now refuses to run instead of guessing.
+downstream can detect this, so the pipeline refuses to run.
 
 Check with **Image > Properties** in Fiji: unit should be `micron`, with pixel
 width/height/depth set to your acquisition's voxel size. Fix it and re-export the landmarks
@@ -102,7 +102,7 @@ Re-run without the flag to continue. Check the QA overlays under
   `params.rotation_2p_to_HCR` and answer the orientation prompt with the flip that matches.
 - **Centre fine, edges stretched.** Too few landmarks, or none near the rim. Add points
   toward the boundary.
-- **Overlay looks stringy or scrambled.** The 2P placement is off rather than the landmarks.
+- **Overlay looks stringy or scrambled.** The 2P placement is off, not the landmarks.
   In hi-res mode, check the low-res to hi-res placement step.
 - **Overlay looks right, merged table looks wrong.** Suspect z. Confirm the FISH `z` values
   are per-cell focal slices and not all the same value.


### PR DESCRIPTION
demo/README carried a six-line explanation of why to answer "n" at one prompt and a twenty-line maintainer section with a postmortem in it; both are down to what a reader needs. The README's feature-table section explained a design decision that only means something if you saw the old format, and the output tree pointed at aligned_masks/ as the thing to open when the feature table is the actual product. Also notes that tables are written as csv as well as pickle.